### PR TITLE
FOLSPRINGB-11 Fix issue with unsatisfied dependency

### DIFF
--- a/src/main/java/org/folio/spring/service/TenantService.java
+++ b/src/main/java/org/folio/spring/service/TenantService.java
@@ -9,12 +9,15 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.exception.NotFoundException;
 import org.folio.spring.liquibase.FolioSpringLiquibase;
+
+import org.springframework.context.annotation.Lazy;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 
 @Log4j2
 @RequiredArgsConstructor
 @Service
+@Lazy
 public class TenantService {
   private static final String DESTROY_SQL = "DROP SCHEMA IF EXISTS %1$s CASCADE; DROP ROLE IF EXISTS %1$s";
   private static final String EXIST_SQL = "SELECT EXISTS(SELECT 1 FROM pg_namespace WHERE nspname=?)";


### PR DESCRIPTION
## Purpose
Fix UnsatisfiedDependencyException: Error creating bean with name ‘tenantService’

## Approach
Current approach of removing database support in module is:
1. Creating bean `folioTenantController` that implements `TenantApi`
2. Add properties to `application.properties`:
```
spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration, org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration, org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration
spring.liquibase.enabled=false
```
`@Lazy` annotation on `TenantService` is needed to tell Spring to create this bean only if it is needed by default implementation of `TenantApi`