### PR TITLE
FOLSPRINGB-12: Create system user during tenant initialization (if stated to)

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Please add following properties to your application property file:
 application:
   system-user:
     username: <username-for-the-user>
-    password: <password-for-the-user>
+    password: ${SYSTEM_USER_PASSWORD}
     lastname: <lastname> # e.g. System
     permissionsFilePath: <path-to-csv-file-with-permissions> # e.g. classpath:user-permissions.csv
 ```
@@ -28,6 +28,16 @@ API dependencies to your module descriptor file:
 * `login`
 * `permissions`
 
+The `POST` `/_/tenant` must have permissions:
+```javascript
+"modulePermissions": [
+    "users.collection.get",
+    "users.item.post",
+    "login.item.post",
+    "perms.users.item.post"
+]
+```
+
 Permissions file is a simple CSV file with each permission on a separate file, e.g.:
 ```
 inventory-storage.instance.item.post
@@ -36,3 +46,16 @@ inventory-storage.instance.item.get
 
 We also create a new table `system_user_parameters` to persist user credentials. If your module
 supports caching than it will be automatically applied for the `system_user_parameters` table.
+
+### System user naming convention
+
+Please use following rules for your module system user:
+* `lastname` should be specified, it can be `System`, `Automated process`, `etc` value. 
+It is required to have this property so that it is properly displayed on UI in 'actions' 
+table (e.g. loan actions, fee/fine actions, etc);
+* `username` should be module name or a domain identifier (e.g. `mod-search`, `pub-sub`, etc.).
+
+### Security concerns
+
+The user password **must not** be committed directly to git, please inject them via env variable (e.g. 
+for spring `application.system-user.password: ${SYSTEM_USER_PASSWORD}`) or in some another secure way.

--- a/README.md
+++ b/README.md
@@ -6,3 +6,33 @@ This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 This is a library (jar) that contains the basic functionality and main dependencies required for development FOLIO modules using Spring framework.
+
+# Supported features
+
+## Setup a system user for a module
+
+It is possible to register a system user for the module with desired permissions.
+Please add following properties to your application property file:
+```yaml
+application:
+  system-user:
+    username: folio-spring-base
+    password: folio-spring-base-pwd
+    lastname: System
+    permissionsFilePath: classpath:user-permissions.csv
+```
+
+Please note that `username` should be unique for FOLIO. Also, make sure to add following 
+API dependencies to your module descriptor file:
+* `users`
+* `login`
+* `permissions`
+
+Permissions file is a simple CSV file with each permission on a separate file, e.g.:
+```
+inventory-storage.instance.item.post
+inventory-storage.instance.item.get
+```
+
+We also create a new table `system_user_parameters` to persist user credentials. If your module
+supports caching than it will be automatically applied for the `system_user_parameters` table.

--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Please add following properties to your application property file:
 ```yaml
 application:
   system-user:
-    username: folio-spring-base
-    password: folio-spring-base-pwd
-    lastname: System
-    permissionsFilePath: classpath:user-permissions.csv
+    username: <username-for-the-user>
+    password: <password-for-the-user>
+    lastname: <lastname> # e.g. System
+    permissionsFilePath: <path-to-csv-file-with-permissions> # e.g. classpath:user-permissions.csv
 ```
 
 Please note that `username` should be unique for FOLIO. Also, make sure to add following 

--- a/README.md
+++ b/README.md
@@ -44,8 +44,12 @@ inventory-storage.instance.item.post
 inventory-storage.instance.item.get
 ```
 
-We also create a new table `system_user_parameters` to persist user credentials. If your module
-supports caching than it will be automatically applied for the `system_user_parameters` table.
+### Storing system user parameters in DB vs in memory
+
+If your module supports DB (i.e. there is a dataSource bean) we will create a new table `system_user_parameters` 
+to persist user credentials caching is also supported if it is enabled by the module.
+
+If DB is not supported, then credentials are stored in memory.
 
 ### System user naming convention
 

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
     <lombok.version>1.18.16</lombok.version>
     <mapstruct.version>1.4.1.Final</mapstruct.version>
+    <wiremock.version>2.27.2</wiremock.version>
   </properties>
 
   <repositories>
@@ -135,6 +136,12 @@
       <groupId>io.zonky.test</groupId>
       <artifactId>embedded-database-spring-test</artifactId>
       <version>1.6.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.tomakehurst</groupId>
+      <artifactId>wiremock-standalone</artifactId>
+      <version>${wiremock.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/folio/spring/AsyncFolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/AsyncFolioExecutionContext.java
@@ -1,0 +1,51 @@
+package org.folio.spring;
+
+import static java.util.Collections.emptyMap;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+/**
+ * Execution context for a background tasks, e.g. kafka listeners.
+ */
+@AllArgsConstructor
+public final class AsyncFolioExecutionContext implements FolioExecutionContext {
+  private final String tenantId;
+  private final FolioModuleMetadata moduleMetadata;
+
+  @Override
+  public String getTenantId() {
+    return tenantId;
+  }
+
+  @Override
+  public String getOkapiUrl() {
+    throw new UnsupportedOperationException("getOkapiUrl");
+  }
+
+  @Override
+  public String getToken() {
+    throw new UnsupportedOperationException("getToken");
+  }
+
+  @Override
+  public String getUserName() {
+    throw new UnsupportedOperationException("getUserName");
+  }
+
+  @Override
+  public Map<String, Collection<String>> getAllHeaders() {
+    return emptyMap();
+  }
+
+  @Override
+  public Map<String, Collection<String>> getOkapiHeaders() {
+    return emptyMap();
+  }
+
+  @Override
+  public FolioModuleMetadata getFolioModuleMetadata() {
+    return moduleMetadata;
+  }
+}

--- a/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
@@ -1,14 +1,20 @@
 package org.folio.spring;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
 import static org.folio.spring.integration.XOkapiHeaders.OKAPI_HEADERS_PREFIX;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.folio.spring.domain.SystemUser;
+
+@Builder
+@AllArgsConstructor
 public class DefaultFolioExecutionContext implements FolioExecutionContext {
   private final FolioModuleMetadata folioModuleMetadata;
   private final Map<String, Collection<String>> allHeaders;
@@ -32,7 +38,21 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
     this.userName = "NO_USER";
   }
 
-  private String retrieveFirstSafe(Collection<String> strings) {
+  public static DefaultFolioExecutionContext forSystemUser(
+    FolioModuleMetadata folioModuleMetadata, SystemUser systemUser) {
+
+    return DefaultFolioExecutionContext.builder()
+      .allHeaders(Collections.emptyMap())
+      .okapiHeaders(Collections.emptyMap())
+      .folioModuleMetadata(folioModuleMetadata)
+      .tenantId(systemUser.getTenantId())
+      .okapiUrl(systemUser.getOkapiUrl())
+      .token(systemUser.getOkapiToken())
+      .userName(systemUser.getUsername())
+      .build();
+  }
+
+  private static String retrieveFirstSafe(Collection<String> strings) {
     return strings != null && !strings.isEmpty() ? strings.iterator().next() : "";
   }
 

--- a/src/main/java/org/folio/spring/client/AuthnClient.java
+++ b/src/main/java/org/folio/spring/client/AuthnClient.java
@@ -1,0 +1,27 @@
+package org.folio.spring.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient("authn")
+public interface AuthnClient {
+
+  @PostMapping(value = "/login", consumes = APPLICATION_JSON_VALUE)
+  ResponseEntity<String> getApiKey(@RequestBody UserCredentials credentials);
+
+  @PostMapping(value = "/credentials", consumes = APPLICATION_JSON_VALUE)
+  void saveCredentials(@RequestBody UserCredentials credentials);
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  class UserCredentials {
+    private String username;
+    private String password;
+  }
+}

--- a/src/main/java/org/folio/spring/client/PermissionsClient.java
+++ b/src/main/java/org/folio/spring/client/PermissionsClient.java
@@ -1,0 +1,37 @@
+package org.folio.spring.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@FeignClient("perms/users")
+public interface PermissionsClient {
+
+  @PostMapping(consumes = APPLICATION_JSON_VALUE, produces = APPLICATION_JSON_VALUE)
+  void assignPermissionsToUser(@RequestBody Permissions permissions);
+
+  @PostMapping(value = "/{userId}/permissions?indexField=userId", consumes = APPLICATION_JSON_VALUE)
+  void addPermission(@PathVariable("userId") String userId, Permission permission);
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  @NoArgsConstructor
+  class Permission {
+    private String permissionName;
+  }
+
+  @Data
+  @AllArgsConstructor(staticName = "of")
+  class Permissions {
+    private String id;
+    private String userId;
+    private List<String> permissions;
+  }
+}

--- a/src/main/java/org/folio/spring/client/UsersClient.java
+++ b/src/main/java/org/folio/spring/client/UsersClient.java
@@ -1,0 +1,53 @@
+package org.folio.spring.client;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON_VALUE;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.util.Collections;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.Singular;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@FeignClient("users")
+public interface UsersClient {
+  @GetMapping
+  Users query(@RequestParam("query") String query);
+
+  @PostMapping(consumes = APPLICATION_JSON_VALUE)
+  void saveUser(@RequestBody User user);
+
+  @Data
+  @Builder
+  @AllArgsConstructor
+  @NoArgsConstructor
+  class Users {
+    @JsonAlias("total_records")
+    private Integer totalRecords;
+    @Singular
+    private List<User> users = Collections.emptyList();
+  }
+
+  @Data
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  class User {
+    private String id;
+    private String username;
+    private boolean active;
+    private Personal personal;
+
+    @Data
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Personal {
+      private String lastName;
+    }
+  }
+}

--- a/src/main/java/org/folio/spring/config/DataSourceFolioWrapper.java
+++ b/src/main/java/org/folio/spring/config/DataSourceFolioWrapper.java
@@ -1,5 +1,7 @@
 package org.folio.spring.config;
 
+import static org.folio.spring.utils.TenantUtil.isValidTenantName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.springframework.jdbc.datasource.DelegatingDataSource;
@@ -7,11 +9,8 @@ import org.springframework.jdbc.datasource.DelegatingDataSource;
 import javax.sql.DataSource;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.regex.Pattern;
 
 public class DataSourceFolioWrapper extends DelegatingDataSource {
-  private static final Pattern NON_WORD_CHARACTERS = Pattern.compile("[^a-zA-Z0-9_]");
-
   private final FolioExecutionContext folioExecutionContext;
 
   public DataSourceFolioWrapper(DataSource targetDataSource, FolioExecutionContext folioExecutionContext) {
@@ -25,7 +24,7 @@ public class DataSourceFolioWrapper extends DelegatingDataSource {
       var schemaName = "public";
       var tenantId = folioExecutionContext.getTenantId();
       if (StringUtils.isNotBlank(tenantId)) {
-        if (NON_WORD_CHARACTERS.matcher(tenantId).find()) {
+        if (!isValidTenantName(tenantId)) {
           throw new IllegalArgumentException("Invalid tenant name: " + tenantId);
         }
         schemaName = folioExecutionContext.getFolioModuleMetadata().getDBSchemaName(tenantId) + ", public";

--- a/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
+++ b/src/main/java/org/folio/spring/config/FolioSpringConfiguration.java
@@ -1,5 +1,7 @@
 package org.folio.spring.config;
 
+import static org.folio.spring.utils.TenantUtil.isValidTenantName;
+
 import org.apache.commons.lang3.StringUtils;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
@@ -28,15 +30,16 @@ public class FolioSpringConfiguration {
       }
 
       /**
-       * Schema name MUST in in lowercase
+       * Schema name MUST in lowercase
        *
-       * @param tenantId
-       * @return
+       * @param tenantId - Tenant id
+       * @return Schema name
+       * @throws IllegalArgumentException if tenant name is not valid (to prevent SQL injections)
        */
       @Override
       public String getDBSchemaName(String tenantId) {
-        if (StringUtils.isBlank(tenantId)) {
-          throw new IllegalArgumentException("tenantId can't be null or empty");
+        if (!isValidTenantName(tenantId)) {
+          throw new IllegalArgumentException(String.format("Invalid tenant name ['%s']", tenantId));
         }
         return tenantId.toLowerCase() + schemaSuffix;
       }

--- a/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
+++ b/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
@@ -1,5 +1,6 @@
 package org.folio.spring.config;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.FolioModuleMetadata;
@@ -10,14 +11,11 @@ import org.folio.spring.repository.SystemUserRepository;
 import org.folio.spring.repository.impl.DbSystemUserRepository;
 import org.folio.spring.repository.impl.InMemorySystemUserRepository;
 import org.folio.spring.service.SystemUserService;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Configuration
@@ -30,18 +28,14 @@ public class FolioSystemUserConfig {
   private final FolioSystemUserProperties systemUserConf;
 
   @Bean
-  @ConditionalOnMissingBean
-  public SystemUserRepository inMemorySystemUserRepository() {
-    return new InMemorySystemUserRepository();
-  }
+  public SystemUserRepository systemUserRepository(
+    Optional<JdbcTemplate> jdbcTemplate, FolioModuleMetadata moduleMetadata) {
 
-  @Bean
-  @Primary
-  @ConditionalOnBean(JdbcTemplate.class)
-  public SystemUserRepository dbSystemUserRepository(
-    JdbcTemplate jdbcTemplate, FolioModuleMetadata moduleMetadata) {
-
-    return new DbSystemUserRepository(jdbcTemplate, moduleMetadata);
+    if (jdbcTemplate.isPresent()) {
+      return new DbSystemUserRepository(jdbcTemplate.get(), moduleMetadata);
+    } else {
+      return new InMemorySystemUserRepository();
+    }
   }
 
   @Bean

--- a/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
+++ b/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
@@ -1,0 +1,43 @@
+package org.folio.spring.config;
+
+import lombok.RequiredArgsConstructor;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.client.PermissionsClient;
+import org.folio.spring.client.UsersClient;
+import org.folio.spring.repository.SystemUserRepository;
+import org.folio.spring.repository.impl.DbSystemUserRepository;
+import org.folio.spring.service.SystemUserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+@Configuration
+@ConditionalOnProperty(prefix = "application.system-user",
+  name = {"username", "password", "permissions-file-path"})
+@EnableConfigurationProperties(FolioSystemUserProperties.class)
+@EnableFeignClients(clients = {AuthnClient.class, PermissionsClient.class, UsersClient.class})
+@RequiredArgsConstructor
+public class FolioSystemUserConfig {
+  private final FolioSystemUserProperties systemUserConf;
+
+  @Bean
+  public SystemUserRepository systemUserRepository(
+    JdbcTemplate jdbcTemplate, FolioModuleMetadata moduleMetadata) {
+
+    return new DbSystemUserRepository(jdbcTemplate, moduleMetadata);
+  }
+
+  @Bean
+  public SystemUserService systemUserService(
+    PermissionsClient permissionsClient, UsersClient usersClient, AuthnClient authnClient,
+    SystemUserRepository repository, FolioExecutionContext context) {
+
+    return new SystemUserService(permissionsClient, usersClient,
+      authnClient, repository, systemUserConf, context);
+  }
+}

--- a/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
+++ b/src/main/java/org/folio/spring/config/FolioSystemUserConfig.java
@@ -8,12 +8,16 @@ import org.folio.spring.client.PermissionsClient;
 import org.folio.spring.client.UsersClient;
 import org.folio.spring.repository.SystemUserRepository;
 import org.folio.spring.repository.impl.DbSystemUserRepository;
+import org.folio.spring.repository.impl.InMemorySystemUserRepository;
 import org.folio.spring.service.SystemUserService;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 @Configuration
@@ -26,7 +30,15 @@ public class FolioSystemUserConfig {
   private final FolioSystemUserProperties systemUserConf;
 
   @Bean
-  public SystemUserRepository systemUserRepository(
+  @ConditionalOnMissingBean
+  public SystemUserRepository inMemorySystemUserRepository() {
+    return new InMemorySystemUserRepository();
+  }
+
+  @Bean
+  @Primary
+  @ConditionalOnBean(JdbcTemplate.class)
+  public SystemUserRepository dbSystemUserRepository(
     JdbcTemplate jdbcTemplate, FolioModuleMetadata moduleMetadata) {
 
     return new DbSystemUserRepository(jdbcTemplate, moduleMetadata);

--- a/src/main/java/org/folio/spring/config/FolioSystemUserProperties.java
+++ b/src/main/java/org/folio/spring/config/FolioSystemUserProperties.java
@@ -1,0 +1,19 @@
+package org.folio.spring.config;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Data
+@ConfigurationProperties("application.system-user")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FolioSystemUserProperties {
+  private String username;
+  private String password;
+  private String lastname;
+  private String permissionsFilePath;
+}

--- a/src/main/java/org/folio/spring/domain/SystemUser.java
+++ b/src/main/java/org/folio/spring/domain/SystemUser.java
@@ -1,0 +1,20 @@
+package org.folio.spring.domain;
+
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SystemUser {
+  private UUID id;
+  private String username;
+  private String password;
+  private String okapiToken;
+  private String okapiUrl;
+  private String tenantId;
+}

--- a/src/main/java/org/folio/spring/repository/SystemUserRepository.java
+++ b/src/main/java/org/folio/spring/repository/SystemUserRepository.java
@@ -1,0 +1,10 @@
+package org.folio.spring.repository;
+
+import java.util.Optional;
+import org.folio.spring.domain.SystemUser;
+
+public interface SystemUserRepository {
+  Optional<SystemUser> getByTenantId(String tenantId);
+
+  void save(SystemUser systemUser);
+}

--- a/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
+++ b/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
@@ -1,0 +1,51 @@
+package org.folio.spring.repository.impl;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.repository.SystemUserRepository;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.jdbc.BadSqlGrammarException;
+import org.springframework.jdbc.core.BeanPropertyRowMapper;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
+import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
+
+@AllArgsConstructor
+public class DbSystemUserRepository implements SystemUserRepository {
+  public static final String TABLE_NAME = "system_user_parameters";
+  private static final String SYSTEM_USER_CACHE = "systemUserParameters";
+
+  private final JdbcTemplate jdbcTemplate;
+  private final FolioModuleMetadata moduleMetadata;
+
+  @Cacheable(cacheNames = SYSTEM_USER_CACHE, unless = "#result==null")
+  @Override
+  public Optional<SystemUser> getByTenantId(String tenantId) {
+    try {
+      var resultList = jdbcTemplate.query("SELECT * FROM " + getFullTableName(tenantId),
+        new BeanPropertyRowMapper<>(SystemUser.class));
+
+      return resultList.isEmpty()
+        ? Optional.empty() : Optional.of(resultList.get(resultList.size() - 1));
+    } catch (BadSqlGrammarException ex) {
+      // means schema does not exist
+      return Optional.empty();
+    }
+  }
+
+  @CacheEvict(cacheNames = SYSTEM_USER_CACHE, key = "#systemUser.tenantId")
+  @Override
+  public void save(SystemUser systemUser) {
+    new SimpleJdbcInsert(jdbcTemplate)
+      .withSchemaName(moduleMetadata.getDBSchemaName(systemUser.getTenantId()))
+      .withTableName(TABLE_NAME)
+      .execute(new BeanPropertySqlParameterSource(systemUser));
+  }
+
+  private String getFullTableName(String tenantId) {
+    return moduleMetadata.getDBSchemaName(tenantId) + "." + TABLE_NAME;
+  }
+}

--- a/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
+++ b/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
@@ -25,7 +25,7 @@ public class DbSystemUserRepository implements SystemUserRepository {
   @Override
   public Optional<SystemUser> getByTenantId(String tenantId) {
     try {
-      var resultList = jdbcTemplate.query("SELECT * FROM " + getFullTableName(tenantId),
+      var resultList = jdbcTemplate.query(getSelectQuery(tenantId),
         new BeanPropertyRowMapper<>(SystemUser.class));
 
       return resultList.isEmpty()
@@ -45,7 +45,8 @@ public class DbSystemUserRepository implements SystemUserRepository {
       .execute(new BeanPropertySqlParameterSource(systemUser));
   }
 
-  private String getFullTableName(String tenantId) {
-    return moduleMetadata.getDBSchemaName(tenantId) + "." + TABLE_NAME;
+  private String getSelectQuery(String tenantId) {
+    return String.format("SELECT * FROM \"%s\".\"%s\"", moduleMetadata.getDBSchemaName(tenantId),
+      TABLE_NAME);
   }
 }

--- a/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
+++ b/src/main/java/org/folio/spring/repository/impl/DbSystemUserRepository.java
@@ -1,7 +1,9 @@
 package org.folio.spring.repository.impl;
 
 import java.util.Optional;
+import java.util.UUID;
 import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioModuleMetadata;
 import org.folio.spring.domain.SystemUser;
 import org.folio.spring.repository.SystemUserRepository;
@@ -13,6 +15,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.BeanPropertySqlParameterSource;
 import org.springframework.jdbc.core.simple.SimpleJdbcInsert;
 
+@Log4j2
 @AllArgsConstructor
 public class DbSystemUserRepository implements SystemUserRepository {
   public static final String TABLE_NAME = "system_user_parameters";
@@ -39,14 +42,37 @@ public class DbSystemUserRepository implements SystemUserRepository {
   @CacheEvict(cacheNames = SYSTEM_USER_CACHE, key = "#systemUser.tenantId")
   @Override
   public void save(SystemUser systemUser) {
-    new SimpleJdbcInsert(jdbcTemplate)
-      .withSchemaName(moduleMetadata.getDBSchemaName(systemUser.getTenantId()))
-      .withTableName(TABLE_NAME)
-      .execute(new BeanPropertySqlParameterSource(systemUser));
+    if (!userExists(systemUser.getTenantId(), systemUser.getId())) {
+      new SimpleJdbcInsert(jdbcTemplate)
+        .withSchemaName(moduleMetadata.getDBSchemaName(systemUser.getTenantId()))
+        .withTableName(TABLE_NAME)
+        .execute(new BeanPropertySqlParameterSource(systemUser));
+    } else {
+      log.info("User already exists, updating it...");
+
+      jdbcTemplate.update(getUpdateQuery(systemUser.getTenantId()),
+        systemUser.getOkapiToken(), systemUser.getOkapiUrl(), systemUser.getId());
+    }
+  }
+
+  private boolean userExists(String tenant, UUID id) {
+    var count = jdbcTemplate.queryForObject(userExistsQuery(tenant), Integer.class, id);
+    return count != null && count > 0;
+  }
+
+  private String getUpdateQuery(String tenantId) {
+    return String.format("UPDATE \"%s\".\"%s\" " +
+        "SET okapi_token = ?, okapi_url = ? " +
+        "WHERE id = ?", moduleMetadata.getDBSchemaName(tenantId), TABLE_NAME);
   }
 
   private String getSelectQuery(String tenantId) {
     return String.format("SELECT * FROM \"%s\".\"%s\"", moduleMetadata.getDBSchemaName(tenantId),
       TABLE_NAME);
+  }
+
+  private String userExistsQuery(String tenantId) {
+    return String.format("SELECT COUNT(*) FROM \"%s\".\"%s\" where id = ?",
+      moduleMetadata.getDBSchemaName(tenantId), TABLE_NAME);
   }
 }

--- a/src/main/java/org/folio/spring/repository/impl/InMemorySystemUserRepository.java
+++ b/src/main/java/org/folio/spring/repository/impl/InMemorySystemUserRepository.java
@@ -1,0 +1,26 @@
+package org.folio.spring.repository.impl;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.repository.SystemUserRepository;
+
+@Log4j2
+@AllArgsConstructor
+public class InMemorySystemUserRepository implements SystemUserRepository {
+  private static final Map<String, SystemUser> systemUsers =
+    new ConcurrentHashMap<>();
+
+  @Override
+  public Optional<SystemUser> getByTenantId(String tenantId) {
+    return Optional.ofNullable(systemUsers.get(tenantId));
+  }
+
+  @Override
+  public void save(SystemUser systemUser) {
+    systemUsers.put(systemUser.getTenantId(), systemUser);
+  }
+}

--- a/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -127,7 +127,8 @@ public class SystemUserService {
       try {
         permissionsClient.addPermission(userId, p);
       } catch (Exception e) {
-        log.info("Error adding permission {} to System User. Permission may be already assigned.", permission);
+        log.info("Error adding permission {} to System User. Permission may be already assigned. Error was {}",
+          permission, e);
       }
     });
   }

--- a/src/main/java/org/folio/spring/service/SystemUserService.java
+++ b/src/main/java/org/folio/spring/service/SystemUserService.java
@@ -1,0 +1,149 @@
+package org.folio.spring.service;
+
+import static org.folio.spring.client.AuthnClient.UserCredentials;
+import static org.folio.spring.client.PermissionsClient.Permission;
+import static org.folio.spring.client.PermissionsClient.Permissions;
+import static org.folio.spring.client.UsersClient.User;
+import static org.folio.spring.utils.ResourceUtil.getResourceLines;
+import static org.springframework.util.CollectionUtils.isEmpty;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import lombok.AllArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.client.PermissionsClient;
+import org.folio.spring.client.UsersClient;
+import org.folio.spring.config.FolioSystemUserProperties;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.repository.SystemUserRepository;
+import org.springframework.util.CollectionUtils;
+
+@Log4j2
+@AllArgsConstructor
+public class SystemUserService {
+  private final PermissionsClient permissionsClient;
+  private final UsersClient usersClient;
+  private final AuthnClient authnClient;
+  private final SystemUserRepository systemUserRepository;
+  private final FolioSystemUserProperties folioSystemUserConf;
+  private final FolioExecutionContext folioContext;
+
+  public void prepareSystemUser() {
+    var systemUserParameters = systemUserRepository
+      .getByTenantId(folioContext.getTenantId())
+      .orElse(buildDefaultSystemUserParameters());
+
+    var folioUser = getFolioUser(systemUserParameters.getUsername());
+
+    if (folioUser.isPresent()) {
+      addPermissions(folioUser.get().getId());
+    } else {
+      var userId = createFolioUser();
+      saveCredentials(systemUserParameters);
+      assignPermissions(userId);
+    }
+
+    var backgroundUserApiKey = loginSystemUser(systemUserParameters);
+    systemUserParameters.setOkapiToken(backgroundUserApiKey);
+    saveSystemUserParameters(systemUserParameters);
+  }
+
+  private String loginSystemUser(SystemUser params) {
+    var response = authnClient.getApiKey(UserCredentials
+      .of(params.getUsername(), params.getPassword()));
+
+    var headers = response.getHeaders().get(XOkapiHeaders.TOKEN);
+    if (CollectionUtils.isEmpty(headers)) {
+      throw new IllegalStateException(String.format("User [%s] cannot log in", params.getUsername()));
+    } else {
+      return headers.get(0);
+    }
+  }
+
+  private SystemUser buildDefaultSystemUserParameters() {
+    return SystemUser.builder()
+      .id(UUID.randomUUID())
+      .username(folioSystemUserConf.getUsername())
+      .password(folioSystemUserConf.getPassword())
+      .okapiUrl(folioContext.getOkapiUrl())
+      .tenantId(folioContext.getTenantId()).build();
+  }
+
+  private void saveSystemUserParameters(SystemUser systemUserParams) {
+    systemUserRepository.save(systemUserParams);
+  }
+
+  public SystemUser getSystemUserParameters(String tenantId) {
+    return systemUserRepository.getByTenantId(tenantId)
+      .orElseThrow(() -> new IllegalArgumentException("No system user for tenant " + tenantId));
+  }
+
+  private Optional<UsersClient.User> getFolioUser(String username) {
+    var users = usersClient.query("username==" + username);
+    return users.getUsers().stream().findFirst();
+  }
+
+  private String createFolioUser() {
+    final var user = createUserObject();
+    final var id = user.getId();
+    usersClient.saveUser(user);
+    return id;
+  }
+
+  private void saveCredentials(SystemUser parameters) {
+    authnClient.saveCredentials(UserCredentials.of(parameters.getUsername(),
+      parameters.getPassword()));
+
+    log.info("Saved credentials for user: [{}]", parameters.getUsername());
+  }
+
+  private void assignPermissions(String userId) {
+    List<String> perms = getResourceLines(folioSystemUserConf.getPermissionsFilePath());
+
+    if (isEmpty(perms)) {
+      throw new IllegalStateException("No permissions found to assign to user with id: " + userId);
+    }
+
+    var permissions = Permissions.of(UUID.randomUUID()
+      .toString(), userId, perms);
+
+    permissionsClient.assignPermissionsToUser(permissions);
+  }
+
+  private void addPermissions(String userId) {
+    var permissions = getResourceLines(folioSystemUserConf.getPermissionsFilePath());
+
+    if (isEmpty(permissions)) {
+      throw new IllegalStateException("No permissions found to assign to user with id: " + userId);
+    }
+
+    permissions.forEach(permission -> {
+      var p = new Permission();
+      p.setPermissionName(permission);
+      try {
+        permissionsClient.addPermission(userId, p);
+      } catch (Exception e) {
+        log.info("Error adding permission {} to System User. Permission may be already assigned.", permission);
+      }
+    });
+  }
+
+  private User createUserObject() {
+    final var user = new User();
+
+    user.setId(UUID.randomUUID()
+      .toString());
+    user.setActive(true);
+    user.setUsername(folioSystemUserConf.getUsername());
+
+    user.setPersonal(new User.Personal());
+    user.getPersonal()
+      .setLastName(folioSystemUserConf.getLastname());
+
+    return user;
+  }
+}

--- a/src/main/java/org/folio/spring/service/TenantScopedExecutionService.java
+++ b/src/main/java/org/folio/spring/service/TenantScopedExecutionService.java
@@ -1,0 +1,51 @@
+package org.folio.spring.service;
+
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext;
+import static org.folio.spring.scope.FolioExecutionScopeExecutionContextManager.endFolioExecutionContext;
+
+import java.util.Optional;
+import lombok.AllArgsConstructor;
+import lombok.SneakyThrows;
+import org.folio.spring.AsyncFolioExecutionContext;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+
+@AllArgsConstructor
+public class TenantScopedExecutionService {
+  private final FolioModuleMetadata moduleMetadata;
+  private final Optional<SystemUserService> systemUserServiceOptional;
+
+  /**
+   * Executes given job tenant scoped. If a system user is configured, then
+   * it is used for as {@link FolioExecutionContext} implementation, otherwise
+   * an {@link AsyncFolioExecutionContext} is used.
+   *
+   * @param tenantId - The tenant name.
+   * @param job      - Job to be executed in tenant scope.
+   * @param <T>      - Optional return value for the job.
+   * @return Result of job.
+   * @throws RuntimeException - Wrapped exception from the job.
+   */
+  @SneakyThrows
+  public <T> T executeTenantScoped(String tenantId, ThrowableSupplier<T> job) {
+    try {
+      beginFolioExecutionContext(folioExecutionContext(tenantId));
+      return job.get();
+    } finally {
+      endFolioExecutionContext();
+    }
+  }
+
+  private FolioExecutionContext folioExecutionContext(String tenantId) {
+    return systemUserServiceOptional.isPresent()
+      ? DefaultFolioExecutionContext.forSystemUser(moduleMetadata,
+      systemUserServiceOptional.get().getSystemUserParameters(tenantId))
+      : new AsyncFolioExecutionContext(tenantId, moduleMetadata);
+  }
+
+  @FunctionalInterface
+  public interface ThrowableSupplier<T> {
+    T get() throws Exception;
+  }
+}

--- a/src/main/java/org/folio/spring/utils/ResourceUtil.java
+++ b/src/main/java/org/folio/spring/utils/ResourceUtil.java
@@ -1,0 +1,15 @@
+package org.folio.spring.utils;
+
+import java.nio.file.Files;
+import java.util.List;
+import lombok.SneakyThrows;
+import lombok.experimental.UtilityClass;
+import org.springframework.util.ResourceUtils;
+
+@UtilityClass
+public class ResourceUtil {
+  @SneakyThrows
+  public static List<String> getResourceLines(String path) {
+    return Files.readAllLines(ResourceUtils.getFile(path).toPath());
+  }
+}

--- a/src/main/java/org/folio/spring/utils/TenantUtil.java
+++ b/src/main/java/org/folio/spring/utils/TenantUtil.java
@@ -1,0 +1,15 @@
+package org.folio.spring.utils;
+
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+
+import java.util.regex.Pattern;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class TenantUtil {
+  private static final Pattern NON_WORD_CHARACTERS = Pattern.compile("[^a-zA-Z0-9_]");
+
+  public static boolean isValidTenantName(String tenant) {
+    return isNotBlank(tenant) && !NON_WORD_CHARACTERS.matcher(tenant).find();
+  }
+}

--- a/src/test/java/org/folio/spring/config/DataSourceFolioWrapperTest.java
+++ b/src/test/java/org/folio/spring/config/DataSourceFolioWrapperTest.java
@@ -1,0 +1,77 @@
+package org.folio.spring.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import javax.sql.DataSource;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DataSourceFolioWrapperTest {
+  @Mock
+  private Connection connection;
+  @Mock
+  private DataSource dataSource;
+  @Mock
+  private FolioExecutionContext executionContext;
+  @InjectMocks
+  private DataSourceFolioWrapper wrapper;
+
+  @BeforeEach
+  void setUpStubs() throws Exception {
+    when(dataSource.getConnection()).thenReturn(connection);
+  }
+
+  @Test
+  void shouldThrowIllegalArgumentIfTenantIsNotValid() {
+    when(executionContext.getTenantId()).thenReturn("f\"_drop_table");
+
+    assertThrows(IllegalArgumentException.class, () -> wrapper.getConnection());
+  }
+
+  @Test
+  void shouldReturnConnectionIfTenantValid() throws Exception {
+    var preparedStatement = mock(PreparedStatement.class);
+
+    when(executionContext.getTenantId()).thenReturn("diku");
+    when(executionContext.getFolioModuleMetadata())
+      .thenReturn(mock(FolioModuleMetadata.class));
+    when(executionContext.getFolioModuleMetadata().getDBSchemaName(any()))
+      .thenReturn("diku_folio_spring_base");
+    when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+
+    assertNotNull(wrapper.getConnection());
+  }
+
+  @Test
+  void shouldReturnConnectionIfTenantIsNull() throws Exception {
+    var preparedStatement = mock(PreparedStatement.class);
+
+    when(executionContext.getTenantId()).thenReturn(null);
+    when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+
+    assertNotNull(wrapper.getConnection());
+  }
+
+  @Test
+  void shouldReturnConnectionIfTenantIsEmpty() throws Exception {
+    var preparedStatement = mock(PreparedStatement.class);
+
+    when(executionContext.getTenantId()).thenReturn("");
+    when(connection.prepareStatement(any())).thenReturn(preparedStatement);
+
+    assertNotNull(wrapper.getConnection());
+  }
+}

--- a/src/test/java/org/folio/spring/config/FolioModuleMetadataTest.java
+++ b/src/test/java/org/folio/spring/config/FolioModuleMetadataTest.java
@@ -1,0 +1,25 @@
+package org.folio.spring.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+class FolioModuleMetadataTest {
+  @Test
+  void shouldReturnSchemaNameIfTenantValid() {
+    assertEquals("valid_tenant_name_folio_spring_base",
+      getDBSchemaName("valid_tenant_name"));
+  }
+
+  @Test
+  void shouldThrowExceptionIfTenantInvalid() {
+    assertThrows(IllegalArgumentException.class,
+      () -> getDBSchemaName("drop schema"));
+  }
+
+  private String getDBSchemaName(String tenant) {
+    return new FolioSpringConfiguration()
+      .folioModuleMetadata("folio-spring-base").getDBSchemaName(tenant);
+  }
+}

--- a/src/test/java/org/folio/spring/service/SystemUserInMemoryIT.java
+++ b/src/test/java/org/folio/spring/service/SystemUserInMemoryIT.java
@@ -1,0 +1,64 @@
+package org.folio.spring.service;
+
+import static org.folio.spring.support.TestBase.TENANT_NAME;
+import static org.folio.spring.support.TestBase.getOkapiUrl;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+
+import java.util.UUID;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.repository.SystemUserRepository;
+import org.folio.spring.repository.impl.InMemorySystemUserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
+import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@TestPropertySource(value = {
+  "classpath:enable-sys-user.properties",
+  "classpath:application.properties"},
+  properties = "spring.liquibase.enabled=false")
+class SystemUserInMemoryIT {
+  @Autowired
+  private SystemUserRepository repository;
+
+  @Configuration
+  @EnableAutoConfiguration(exclude = {
+    DataSourceAutoConfiguration.class, HibernateJpaAutoConfiguration.class,
+    DataSourceTransactionManagerAutoConfiguration.class})
+  static class NoDbConfiguration {}
+
+  @Test
+  void shouldCreateUser() {
+    assertThat(repository, instanceOf(InMemorySystemUserRepository.class));
+
+    var systemUser = SystemUser.builder()
+      .id(UUID.randomUUID())
+      .tenantId(TENANT_NAME)
+      .okapiToken("new_token")
+      .username("new_user")
+      .password("password")
+      .okapiUrl(getOkapiUrl())
+      .build();
+
+    repository.save(systemUser);
+
+    var finalSystemUser = repository.getByTenantId(TENANT_NAME).get();
+
+    assertThat(finalSystemUser.getId(), is(systemUser.getId()));
+    assertThat(finalSystemUser.getUsername(), is("new_user"));
+    assertThat(finalSystemUser.getPassword(), is("password"));
+    assertThat(finalSystemUser.getOkapiToken(), is("new_token"));
+    assertThat(finalSystemUser.getOkapiUrl(), is(getOkapiUrl()));
+    assertThat(finalSystemUser.getTenantId(), is(TENANT_NAME));
+  }
+}

--- a/src/test/java/org/folio/spring/service/SystemUserRepositoryCacheIT.java
+++ b/src/test/java/org/folio/spring/service/SystemUserRepositoryCacheIT.java
@@ -9,10 +9,12 @@ import java.util.UUID;
 import org.folio.spring.domain.SystemUser;
 import org.folio.spring.repository.SystemUserRepository;
 import org.folio.spring.support.TestBase;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource({"classpath:enable-sys-user.properties", "classpath:application.properties"})
@@ -24,6 +26,11 @@ class SystemUserRepositoryCacheIT extends TestBase {
   private SystemUserRepository repository;
   @Autowired
   private CacheManager cacheManager;
+
+  @AfterEach
+  void removeSystemUsers(@Autowired JdbcTemplate template) {
+    template.execute("DELETE FROM test_tenant_folio_spring_base.system_user_parameters");
+  }
 
   @Test
   void shouldPutIntoCacheWhenResultExists() {
@@ -52,5 +59,54 @@ class SystemUserRepositoryCacheIT extends TestBase {
     assertThat(systemUserOptional.isPresent(), is(false));
     assertThat(cacheManager.getCache(CACHE_NAME), notNullValue());
     assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT_NAME), is(nullValue()));
+  }
+
+  @Test
+  void shouldUpdateUserIfExists() {
+    var systemUser = SystemUser.builder()
+      .id(UUID.randomUUID())
+      .tenantId(TENANT_NAME)
+      .username("folio-spring-base")
+      .password("password")
+      .okapiToken("aa.bb.cc")
+      .okapiUrl(getOkapiUrl());
+
+    var originSystemUser = systemUser.build();
+    repository.save(originSystemUser);
+
+    // Should update the user
+    repository.save(systemUser.okapiToken("new_token").okapiUrl("new_url").build());
+
+    var updatedSystemUser = repository.getByTenantId(TENANT_NAME).get();
+
+    assertThat(updatedSystemUser.getId(), is(originSystemUser.getId()));
+    assertThat(updatedSystemUser.getUsername(), is(originSystemUser.getUsername()));
+    assertThat(updatedSystemUser.getPassword(), is(originSystemUser.getPassword()));
+    assertThat(updatedSystemUser.getOkapiToken(), is("new_token"));
+    assertThat(updatedSystemUser.getOkapiUrl(), is("new_url"));
+    assertThat(updatedSystemUser.getTenantId(), is(TENANT_NAME));
+  }
+
+  @Test
+  void shouldCreateUser() {
+    var systemUser = SystemUser.builder()
+      .id(UUID.randomUUID())
+      .tenantId(TENANT_NAME)
+      .okapiToken("new_token")
+      .username("new_user")
+      .password("password")
+      .okapiUrl(getOkapiUrl())
+      .build();
+
+    repository.save(systemUser);
+
+    var finalSystemUser = repository.getByTenantId(TENANT_NAME).get();
+
+    assertThat(finalSystemUser.getId(), is(systemUser.getId()));
+    assertThat(finalSystemUser.getUsername(), is("new_user"));
+    assertThat(finalSystemUser.getPassword(), is("password"));
+    assertThat(finalSystemUser.getOkapiToken(), is("new_token"));
+    assertThat(finalSystemUser.getOkapiUrl(), is(getOkapiUrl()));
+    assertThat(finalSystemUser.getTenantId(), is(TENANT_NAME));
   }
 }

--- a/src/test/java/org/folio/spring/service/SystemUserRepositoryCacheIT.java
+++ b/src/test/java/org/folio/spring/service/SystemUserRepositoryCacheIT.java
@@ -1,0 +1,56 @@
+package org.folio.spring.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.UUID;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.repository.SystemUserRepository;
+import org.folio.spring.support.TestBase;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource({"classpath:enable-sys-user.properties", "classpath:application.properties"})
+@EnableCaching
+class SystemUserRepositoryCacheIT extends TestBase {
+  private static final String CACHE_NAME = "systemUserParameters";
+
+  @Autowired
+  private SystemUserRepository repository;
+  @Autowired
+  private CacheManager cacheManager;
+
+  @Test
+  void shouldPutIntoCacheWhenResultExists() {
+    var systemUser = SystemUser.builder()
+      .id(UUID.randomUUID())
+      .tenantId(TENANT_NAME)
+      .okapiToken("aa.bb.cc")
+      .username("username")
+      .password("password")
+      .okapiUrl(getOkapiUrl())
+      .build();
+
+    repository.save(systemUser);
+    var systemUserOptional = repository.getByTenantId(TENANT_NAME);
+
+    assertThat(systemUserOptional.isPresent(), is(true));
+    assertThat(cacheManager.getCache(CACHE_NAME), notNullValue());
+    assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT_NAME, SystemUser.class),
+      is(systemUser));
+  }
+
+  @Test
+  void shouldNotPutIntoCacheWhenResultIsNull() {
+    var systemUserOptional = repository.getByTenantId("undefined_tenant");
+
+    assertThat(systemUserOptional.isPresent(), is(false));
+    assertThat(cacheManager.getCache(CACHE_NAME), notNullValue());
+    assertThat(cacheManager.getCache(CACHE_NAME).get(TENANT_NAME), is(nullValue()));
+  }
+}

--- a/src/test/java/org/folio/spring/service/SystemUserServiceIT.java
+++ b/src/test/java/org/folio/spring/service/SystemUserServiceIT.java
@@ -1,0 +1,46 @@
+package org.folio.spring.service;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.folio.spring.repository.SystemUserRepository;
+import org.folio.spring.support.TestBase;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+@TestPropertySource({"classpath:enable-sys-user.properties", "classpath:application.properties"})
+class SystemUserServiceIT extends TestBase {
+  @Autowired
+  private SystemUserRepository userRepository;
+
+  @Test
+  void shouldCreateSystemUserDuringTenantInit() throws Exception {
+    var tenantId = "shouldCreateSystemUserDuringTenantInit";
+
+    mockMvc.perform(post("/_/tenant")
+      .headers(defaultHeaders(tenantId))
+      .content(toJsonString(new TenantAttributes()
+        .moduleTo("folio-spring-base-1.0.0"))))
+      .andExpect(status().isOk());
+
+    wireMockServer.verify(getRequestedFor(urlEqualTo("/users?query=username%3D%3Dfolio-spring-base")));
+    wireMockServer.verify(postRequestedFor(urlEqualTo("/users")));
+    wireMockServer.verify(postRequestedFor(urlEqualTo("/authn/credentials")));
+    wireMockServer.verify(postRequestedFor(urlEqualTo("/perms/users")));
+    wireMockServer.verify(postRequestedFor(urlEqualTo("/authn/login")));
+
+    var systemUserOptional = userRepository.getByTenantId(tenantId);
+    assertThat(systemUserOptional.isPresent(), is(true));
+    assertThat(systemUserOptional.get().getTenantId(), is(tenantId));
+    assertThat(systemUserOptional.get().getOkapiToken(), is("aa.bb.cc"));
+    assertThat(systemUserOptional.get().getUsername(), is("folio-spring-base"));
+    assertThat(systemUserOptional.get().getPassword(), is("folio-spring-base-pwd"));
+  }
+}

--- a/src/test/java/org/folio/spring/service/SystemUserServiceTest.java
+++ b/src/test/java/org/folio/spring/service/SystemUserServiceTest.java
@@ -1,0 +1,179 @@
+package org.folio.spring.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.client.AuthnClient;
+import org.folio.spring.client.PermissionsClient;
+import org.folio.spring.client.UsersClient;
+import org.folio.spring.config.FolioSystemUserProperties;
+import org.folio.spring.domain.SystemUser;
+import org.folio.spring.integration.XOkapiHeaders;
+import org.folio.spring.repository.SystemUserRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class SystemUserServiceTest {
+  @Mock
+  private UsersClient usersClient;
+  @Mock
+  private AuthnClient authnClient;
+  @Mock
+  private PermissionsClient permissionsClient;
+  @Mock
+  private FolioExecutionContext executionContext;
+  @Mock
+  private SystemUserRepository repository;
+
+  @Test
+  void shouldCreateSystemUserWhenNotExist() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+    when(usersClient.query(any())).thenReturn(userNotExistResponse());
+    when(authnClient.getApiKey(any())).thenReturn(ResponseEntity.status(200)
+      .header(XOkapiHeaders.TOKEN, "token").build());
+
+    prepareSystemUser(systemUser());
+
+    verify(usersClient).saveUser(any());
+    verify(permissionsClient).assignPermissionsToUser(any());
+
+    var captor = ArgumentCaptor.forClass(SystemUser.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getUsername(), is(systemUser().getUsername()));
+    assertThat(captor.getValue().getPassword(), is(systemUser().getPassword()));
+    assertThat(captor.getValue().getOkapiToken(), is("token"));
+  }
+
+  @Test
+  void shouldNotCreateSystemUserWhenExists() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+    when(authnClient.getApiKey(any())).thenReturn(ResponseEntity.status(200)
+      .header(XOkapiHeaders.TOKEN, "token2").build());
+
+    prepareSystemUser(systemUser());
+
+    verify(permissionsClient, times(2)).addPermission(any(), any());
+
+    var captor = ArgumentCaptor.forClass(SystemUser.class);
+    verify(repository).save(captor.capture());
+
+    assertThat(captor.getValue().getUsername(), is(systemUser().getUsername()));
+    assertThat(captor.getValue().getPassword(), is(systemUser().getPassword()));
+    assertThat(captor.getValue().getOkapiToken(), is("token2"));
+  }
+
+  @Test
+  void cannotAssignPermissionsIfEmptyFile() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+    when(usersClient.query(any())).thenReturn(userNotExistResponse());
+
+    assertThrows(IllegalStateException.class,
+      () -> prepareSystemUser(systemUserNoPermissions()));
+
+    verify(usersClient).saveUser(any());
+    verifyNoInteractions(permissionsClient);
+    verify(repository, times(0)).save(any());
+  }
+
+  @Test
+  void cannotAddPermissionsIfEmptyFile() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+
+    assertThrows(IllegalStateException.class,
+      () -> prepareSystemUser(systemUserNoPermissions()));
+
+    verify(usersClient).query(any());
+    verifyNoInteractions(permissionsClient);
+    verify(repository, times(0)).save(any());
+  }
+
+  @Test
+  void shouldIgnoreErrorWhenPermissionExists() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+    when(usersClient.query(any())).thenReturn(userExistsResponse());
+    when(authnClient.getApiKey(any())).thenReturn(ResponseEntity.status(200)
+      .header(XOkapiHeaders.TOKEN, "token").build());
+
+    var permission = PermissionsClient.Permission.of("inventory-storage.instance.item.get");
+    doThrow(new RuntimeException("Permission exists"))
+      .when(permissionsClient).addPermission(any(), eq(permission));
+
+    prepareSystemUser(systemUser());
+
+    verify(repository).save(any());
+  }
+
+  @Test
+  void shouldReturnSystemUserFromRepository() {
+    when(repository.getByTenantId(any()))
+      .thenReturn(Optional.of(new SystemUser()));
+
+    var user = systemUserService(null).getSystemUserParameters("tenant");
+
+    assertThat(user, notNullValue());
+  }
+
+  @Test
+  void shouldThrowExceptionIfNoUser() {
+    when(repository.getByTenantId(any())).thenReturn(Optional.empty());
+
+    var systemUserService = systemUserService(null);
+
+    assertThrows(IllegalArgumentException.class,
+      () -> systemUserService.getSystemUserParameters("tenant"));
+  }
+
+  private FolioSystemUserProperties systemUser() {
+    return FolioSystemUserProperties.builder()
+      .password("password")
+      .username("username")
+      .permissionsFilePath("classpath:user-permissions.csv")
+      .build();
+  }
+
+  private FolioSystemUserProperties systemUserNoPermissions() {
+    return FolioSystemUserProperties.builder()
+      .password("password")
+      .username("username")
+      .permissionsFilePath("classpath:empty-permissions.csv")
+      .build();
+  }
+
+  private UsersClient.Users userExistsResponse() {
+    return UsersClient.Users.builder()
+      .user(new UsersClient.User())
+      .build();
+  }
+
+  private UsersClient.Users userNotExistResponse() {
+    return new UsersClient.Users();
+  }
+
+  private SystemUserService systemUserService(FolioSystemUserProperties properties) {
+    return new SystemUserService(permissionsClient, usersClient, authnClient,
+      repository, properties, executionContext);
+  }
+
+  private void prepareSystemUser(FolioSystemUserProperties properties) {
+    systemUserService(properties).prepareSystemUser();
+  }
+}

--- a/src/test/java/org/folio/spring/service/TenantScopedExecutionServiceTest.java
+++ b/src/test/java/org/folio/spring/service/TenantScopedExecutionServiceTest.java
@@ -1,0 +1,52 @@
+package org.folio.spring.service;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.domain.SystemUser;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class TenantScopedExecutionServiceTest {
+  public static final String TENANT = "tenant";
+  @Mock
+  private FolioModuleMetadata moduleMetadata;
+  @Mock
+  private SystemUserService systemUserService;
+
+  @Test
+  @SuppressWarnings("all")
+  void shouldUseSystemUserContextWhenPresent() {
+    var service = new TenantScopedExecutionService(moduleMetadata,
+      Optional.of(systemUserService));
+
+    when(systemUserService.getSystemUserParameters(TENANT))
+      .thenReturn(new SystemUser());
+
+    var job = mock(TenantScopedExecutionService.ThrowableSupplier.class);
+
+    service.executeTenantScoped(TENANT, job);
+
+    verify(systemUserService).getSystemUserParameters(TENANT);
+  }
+
+  @Test
+  @SuppressWarnings("all")
+  void shouldUseAsyncUserContextWhenSystemUserNotPresent() throws Exception {
+    var service = new TenantScopedExecutionService(moduleMetadata, Optional.empty());
+    var job = mock(TenantScopedExecutionService.ThrowableSupplier.class);
+
+    service.executeTenantScoped(TENANT, job);
+
+    verifyNoInteractions(systemUserService);
+    verify(job, times(1)).get();
+  }
+}

--- a/src/test/java/org/folio/spring/support/DbConfiguration.java
+++ b/src/test/java/org/folio/spring/support/DbConfiguration.java
@@ -1,0 +1,17 @@
+package org.folio.spring.support;
+
+import javax.sql.DataSource;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.flyway.FlywayAutoConfiguration;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableAutoConfiguration(exclude = FlywayAutoConfiguration.class)
+public class DbConfiguration {
+  @Bean
+  DataSource dataSource() {
+    return DataSourceBuilder.create().build();
+  }
+}

--- a/src/test/java/org/folio/spring/support/TestBase.java
+++ b/src/test/java/org/folio/spring/support/TestBase.java
@@ -1,0 +1,71 @@
+package org.folio.spring.support;
+
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.folio.spring.integration.XOkapiHeaders.URL;
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.util.SocketUtils.findAvailableTcpPort;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+import lombok.SneakyThrows;
+import org.folio.tenant.domain.dto.TenantAttributes;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest(classes = DbConfiguration.class)
+@AutoConfigureEmbeddedDatabase(beanName = "dataSource")
+@AutoConfigureMockMvc
+public abstract class TestBase {
+  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final int WIRE_MOCK_PORT = findAvailableTcpPort();
+  public static final String TENANT_NAME = "test_tenant";
+  protected static WireMockServer wireMockServer;
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @BeforeAll
+  static void testSetup(@Autowired MockMvc mockMvc) throws Exception {
+    wireMockServer = new WireMockServer(WIRE_MOCK_PORT);
+    wireMockServer.start();
+
+    mockMvc.perform(post("/_/tenant")
+      .headers(defaultHeaders(TENANT_NAME))
+      .content(toJsonString(new TenantAttributes()
+        .moduleTo("folio-spring-base-1.0.0"))))
+      .andExpect(status().isOk())
+      .andExpect(content().string("true"));
+  }
+
+  @AfterAll
+  static void tearDown() {
+    wireMockServer.stop();
+  }
+
+  public static HttpHeaders defaultHeaders(String tenant) {
+    var headers = new HttpHeaders();
+    headers.setContentType(APPLICATION_JSON);
+    headers.add(TENANT, tenant);
+    headers.add(URL, getOkapiUrl());
+
+    return headers;
+  }
+
+  @SneakyThrows
+  public static String toJsonString(Object obj) {
+    return OBJECT_MAPPER.writeValueAsString(obj);
+  }
+
+  public static String getOkapiUrl() {
+    return String.format("http://localhost:%s", WIRE_MOCK_PORT);
+  }
+}

--- a/src/test/java/org/folio/spring/utils/TenantUtilTest.java
+++ b/src/test/java/org/folio/spring/utils/TenantUtilTest.java
@@ -1,0 +1,34 @@
+package org.folio.spring.utils;
+
+import static org.folio.spring.utils.TenantUtil.isValidTenantName;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class TenantUtilTest {
+  @ParameterizedTest
+  @ValueSource(strings = {
+    "fs900000",
+    "main_library",
+    "library10000",
+    "diku"
+  })
+  void tenantNameIsValid(String validTenantName) {
+    assertTrue(isValidTenantName(validTenantName));
+  }
+
+  @ParameterizedTest
+  @CsvSource(value = {
+    "drop schema",
+    "a\"destroy",
+    "fs 9000",
+    "null",
+    "\"  \""
+  }, nullValues = "null")
+  void tenantNameIsInvalid(String invalidTenantName) {
+    assertFalse(isValidTenantName(invalidTenantName));
+  }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=folio-spring-base
 spring.liquibase.enabled=true
 spring.liquibase.change-log=classpath:changelog-master.xml
+spring.flyway.enabled=false

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+spring.application.name=folio-spring-base
+spring.liquibase.enabled=true
+spring.liquibase.change-log=classpath:changelog-master.xml

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,6 +1,0 @@
-spring:
-  application:
-    name: folio-spring-base
-  liquibase:
-    enabled: true
-    change-log: classpath:changelog-master.xml

--- a/src/test/resources/enable-sys-user.properties
+++ b/src/test/resources/enable-sys-user.properties
@@ -1,0 +1,4 @@
+application.system-user.username=folio-spring-base
+application.system-user.password=folio-spring-base-pwd
+application.system-user.lastname=System
+application.system-user.permissionsFilePath=classpath:user-permissions.csv

--- a/src/test/resources/mappings/authn.json
+++ b/src/test/resources/mappings/authn.json
@@ -1,0 +1,43 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "POST",
+        "url": "/authn/login"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json",
+          "x-okapi-token": "aa.bb.cc"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "/perms/users"
+      },
+      "response": {
+        "status": 201,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "/authn/credentials"
+      },
+      "response": {
+        "status": 201,
+        "body": "",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}
+

--- a/src/test/resources/mappings/users.json
+++ b/src/test/resources/mappings/users.json
@@ -1,0 +1,29 @@
+{
+  "mappings": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "/users?query=username%3D%3Dfolio-spring-base"
+      },
+      "response": {
+        "status": 200,
+        "body": "{\"users\": [], \"totalRecords\": 0, \"resultInfo\": {\"totalRecords\": 0, \"facets\": [],\"diagnostics\": []}}",
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    },
+    {
+      "request": {
+        "method": "POST",
+        "url": "/users"
+      },
+      "response": {
+        "status": 200,
+        "headers": {
+          "Content-Type": "application/json"
+        }
+      }
+    }
+  ]
+}

--- a/src/test/resources/user-permissions.csv
+++ b/src/test/resources/user-permissions.csv
@@ -1,0 +1,2 @@
+inventory-storage.instance.item.post
+inventory-storage.instance.item.get


### PR DESCRIPTION
https://issues.folio.org/browse/FOLSPRINGB-12 - Move system user create from mod-rs

backported from mod-remote-search - see https://github.com/folio-org/mod-remote-storage/pull/27

## Purpose
Extract system user creation to the base module so that it can be reused by another modules.

## Approach
It is possible to register a system user for the module with desired permissions.
Please add following properties to your application property file:
```yaml
application:
  system-user:
    username: <username-for-the-user>
    password: <password-for-the-user>
    lastname: <lastname> # e.g. System
    permissionsFilePath: <path-to-csv-file-with-permissions> # e.g. classpath:user-permissions.csv
```

Please note that `username` should be unique for FOLIO. Also, make sure to add following 
API dependencies to your module descriptor file:
* `users`
* `login`
* `permissions`

Permissions file is a simple CSV file with each permission on a separate file, e.g.:
```
inventory-storage.instance.item.post
inventory-storage.instance.item.get
```

We also create a new table `system_user_parameters` to persist user credentials. If your module
supports caching than it will be automatically applied for the `system_user_parameters` table.

#### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

## Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
