### PR TITLE
FOLSPRINGB-21 Remove deprecated method getUserName()

### DIFF
--- a/src/main/java/org/folio/spring/FolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/FolioExecutionContext.java
@@ -22,14 +22,6 @@ public interface FolioExecutionContext {
     return null;
   }
 
-  /**
-   * @deprecated Make API call to 'mod-users' to get userName.
-   */
-  @Deprecated(forRemoval = true)
-  default String getUserName() {
-    return null;
-  }
-
   default Map<String, Collection<String>> getAllHeaders() {
     return null;
   }

--- a/src/test/java/org/folio/spring/FolioExecutionContextTest.java
+++ b/src/test/java/org/folio/spring/FolioExecutionContextTest.java
@@ -16,7 +16,6 @@ class FolioExecutionContextTest {
       assertNull(ctx.getOkapiUrl());
       assertNull(ctx.getToken());
       assertNull(ctx.getUserId());
-      assertNull(ctx.getUserName());
       assertNull(ctx.getAllHeaders());
       assertNull(ctx.getOkapiHeaders());
       assertNull(ctx.getFolioModuleMetadata());


### PR DESCRIPTION
## Purpose
Remove deprecated method getUserName() from FolioExecutionContext