### PR TITLE
FOLSPRINGB-21 Setup default logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is a library (jar) that contains the basic functionality and main dependenc
 | `header.validation.x-okapi-tenant.exclude.base-paths` | Specifies base paths to exclude form `x-okapi-tenant` header validation.  See [TenantOkapiHeaderValidationFilter.java](src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java) | `/admin` | `/admin,/swagger-ui` |
 | `folio.jpa.repository.base-packages` | Specifies base packages to scan for repositories  | `org.folio.*` | `org.folio.qm.dao` |
 | `folio.logging.request.enabled` | Turn on logging for incoming requests | `true` | `true or false` |
-| `folio.logging.request.level` | Specifies logging level for incoming requests | `full` | `none, basic, headers, full` |
+| `folio.logging.request.level` | Specifies logging level for incoming requests | `basic` | `none, basic, headers, full` |
 | `folio.logging.feign.enabled` | Turn on logging for outgoing requests in feign clients  | `true` | `true or false` |
 | `folio.logging.feign.level` | Specifies logging level for outgoing requests  | `basic` | `none, basic, headers, full` |
 
@@ -62,34 +62,31 @@ Also, it is possible to specify logging level:
 #### Log examples:
 * basic:
 ```text
-18:41:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
-18:41:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
-18:41:19 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 753ms
-18:41:19 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+18:41:18 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:41:19 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter <--- 202 in 753ms
 ```
 * headers:
 ```text
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-url: http://localhost:50017
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-tenant: test
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-request-id: 90911
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-user-id: 4999cea7-55f8-4f18-b2bc-81155bce8636
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
-18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
-18:44:24 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 786ms
-18:44:24 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-url: http://localhost:50017
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-tenant: <tenandId>
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-request-id: <requestId>
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-user-id: <userId>
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
+18:44:23 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter ---> END HTTP
+18:44:24 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter <--- 202 in 786ms
 ```
 * full:
 ```text
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-url: http://localhost:53146
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-tenant: test
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-request-id: 90911
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-user-id: 4999cea7-55f8-4f18-b2bc-81155bce8636
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter Body: {"parsedRecordId":"c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1","parsedRecordDtoId":"c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c","suppressDiscovery":false}
-18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
-18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 714ms
-18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter Body: 
-18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-url: http://localhost:53146
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-tenant: <tenandId>
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-request-id: <requestId>
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter x-okapi-user-id: <userId>
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter Body: {"parsedRecordId":"c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1","parsedRecordDtoId":"c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c","suppressDiscovery":false}
+18:46:17 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter ---> END HTTP
+18:46:18 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter <--- 202 in 714ms
+18:46:18 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter Body: 
+18:46:18 [<requestId>] [<tenandId>] [<userId>] [<moduleId>] INFO  LoggingRequestFilter <--- END HTTP
 ```

--- a/README.md
+++ b/README.md
@@ -58,3 +58,38 @@ Also, it is possible to specify logging level:
 `basic` - log request method and URI, response status and spent time
 `headers` - log all that `basic` and request headers
 `full` - log all that `headers` and request and response bodies
+
+#### Log examples:
+* basic:
+```text
+18:41:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:41:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
+18:41:19 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 753ms
+18:41:19 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+```
+* headers:
+```text
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-url: http://localhost:50017
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-tenant: test
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-request-id: 90911
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-user-id: 4999cea7-55f8-4f18-b2bc-81155bce8636
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
+18:44:23 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
+18:44:24 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 786ms
+18:44:24 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+```
+* full:
+```text
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> PUT /records-editor/records/c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1 null
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-url: http://localhost:53146
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-tenant: test
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-request-id: 90911
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter x-okapi-user-id: 4999cea7-55f8-4f18-b2bc-81155bce8636
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter content-type: application/json; charset=UTF-8
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter Body: {"parsedRecordId":"c9db5d7a-e1d4-11e8-9f32-f2801f1b9fd1","parsedRecordDtoId":"c56b70ce-4ef6-47ef-8bc3-c470bafa0b8c","suppressDiscovery":false}
+18:46:17 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter ---> END HTTP
+18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- 202 in 714ms
+18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter Body: 
+18:46:18 [90911] [test] [4999cea7-55f8-4f18-b2bc-81155bce8636] [mod-quick-marc] INFO  LoggingRequestFilter <--- END HTTP
+```

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ This is a library (jar) that contains the basic functionality and main dependenc
 | -------- | ----------- | --------| --------|
 | `header.validation.x-okapi-tenant.exclude.base-paths` | Specifies base paths to exclude form `x-okapi-tenant` header validation.  See [TenantOkapiHeaderValidationFilter.java](src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java) | `/admin` | `/admin,/swagger-ui` |
 | `folio.jpa.repository.base-packages` | Specifies base packages to scan for repositories  | `org.folio.*` | `org.folio.qm.dao` |
+| `folio.logging.request.enabled` | Turn on logging for incoming requests | `true` | `true or false` |
+| `folio.logging.request.level` | Specifies logging level for incoming requests | `full` | `none, basic, headers, full` |
+| `folio.logging.feign.enabled` | Turn on logging for outgoing requests in feign clients  | `true` | `true or false` |
+| `folio.logging.feign.level` | Specifies logging level for outgoing requests  | `basic` | `none, basic, headers, full` |
 
 ## CQL support
 To have ability to search entities in databases by CQL-queries:
@@ -34,3 +38,23 @@ public interface JpaCqlRepository<T, ID> extends JpaRepository<T, ID> {
   long count(String cql);
 }
 ```
+
+## Logging
+### Default logging format
+Library uses [log4j2](https://logging.apache.org/log4j/2.x/) for logging. There are two default log4j2 configurations:
+* `log4j2.properties` console/line based logger and it is the default
+* `log4j2-json.properties` JSON structured logging
+  
+To choose the JSON structured logging by using setting: `-Dlog4j.configurationFile=log4j2-json.properties`
+A module that wants to generate log4J2 logs in a different format can create a `log4j2.properties` file in the /resources directory.
+
+### Logging for incoming and outgoing requests
+By default, logging for incoming and outgoing request enabled. Module could disable it by setting: 
+* `folio.logging.request.enabled = false`
+* `folio.logging.feign.enabled = false`
+
+Also, it is possible to specify logging level:
+`none` - no logs
+`basic` - log request method and URI, response status and spent time
+`headers` - log all that `basic` and request headers
+`full` - log all that `headers` and request and response bodies

--- a/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
@@ -1,6 +1,7 @@
 package org.folio.spring;
 
 import static org.folio.spring.integration.XOkapiHeaders.OKAPI_HEADERS_PREFIX;
+import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
@@ -24,6 +25,7 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
   private final String okapiUrl;
   private final String token;
   private final UUID userId;
+  private final String requestId;
 
   public DefaultFolioExecutionContext(FolioModuleMetadata folioModuleMetadata, Map<String, Collection<String>> allHeaders) {
     this.folioModuleMetadata = folioModuleMetadata;
@@ -34,6 +36,7 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
     this.tenantId = retrieveFirstSafe(okapiHeaders.get(TENANT));
     this.okapiUrl = retrieveFirstSafe(okapiHeaders.get(URL));
     this.token = retrieveFirstSafe(okapiHeaders.get(TOKEN));
+    this.requestId = retrieveFirstSafe(okapiHeaders.get(REQUEST_ID));
 
     var userIdString = retrieveFirstSafe(okapiHeaders.get(USER_ID));
     this.userId = userIdString.isEmpty() ? null : UUID.fromString(userIdString);

--- a/src/main/java/org/folio/spring/FolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/FolioExecutionContext.java
@@ -22,6 +22,10 @@ public interface FolioExecutionContext {
     return null;
   }
 
+  default String getRequestId() {
+    return null;
+  }
+
   default Map<String, Collection<String>> getAllHeaders() {
     return null;
   }

--- a/src/main/java/org/folio/spring/config/FeignClientConfiguration.java
+++ b/src/main/java/org/folio/spring/config/FeignClientConfiguration.java
@@ -51,7 +51,8 @@ public class FeignClientConfiguration {
 
     @Override
     protected void log(String configKey, String format, Object... args) {
-      logger.info(String.format(methodTag(configKey) + format, args));
+      var message = String.format(methodTag(configKey) + format, args);
+      logger.info(message);
     }
   }
 }

--- a/src/main/java/org/folio/spring/config/FeignClientConfiguration.java
+++ b/src/main/java/org/folio/spring/config/FeignClientConfiguration.java
@@ -1,10 +1,17 @@
 package org.folio.spring.config;
 
 import feign.Client;
+import feign.Logger;
+
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.client.EnrichUrlAndHeadersClient;
+
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.cloud.openfeign.FeignLoggerFactory;
 import org.springframework.cloud.openfeign.clientconfig.OkHttpFeignConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -19,4 +26,32 @@ public class FeignClientConfiguration {
     return new EnrichUrlAndHeadersClient(folioExecutionContext, okHttpClient);
   }
 
+  @Bean
+  @ConditionalOnProperty(prefix = "folio.logging.feign", name = "enabled", havingValue = "true")
+  public FeignLoggerFactory feignLoggerFactory() {
+    return FeignInfoLogger::new;
+  }
+
+  @Bean
+  public Logger.Level feignLoggerLevel(@Value("${folio.logging.feign.level: BASIC}") Logger.Level level) {
+    return level;
+  }
+
+  public static class FeignInfoLogger extends feign.Logger {
+
+    private final org.slf4j.Logger logger;
+
+    public FeignInfoLogger(Class<?> clazz) {
+      this(LoggerFactory.getLogger(clazz));
+    }
+
+    FeignInfoLogger(org.slf4j.Logger logger) {
+      this.logger = logger;
+    }
+
+    @Override
+    protected void log(String configKey, String format, Object... args) {
+      logger.info(String.format(methodTag(configKey) + format, args));
+    }
+  }
 }

--- a/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
+++ b/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
@@ -1,0 +1,125 @@
+package org.folio.spring.filter;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.time.Instant;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.util.ContentCachingRequestWrapper;
+import org.springframework.web.util.ContentCachingResponseWrapper;
+
+import org.folio.spring.integration.XOkapiHeaders;
+
+@Log4j2
+@Component
+@ConditionalOnProperty(
+  prefix = "folio.logging.request",
+  name = "enabled",
+  havingValue = "true"
+)
+public class LoggingRequestFilter extends GenericFilterBean {
+
+  private static final String START_TIME_ATTR = "startTime";
+
+  private final Level level;
+
+  public LoggingRequestFilter(@Value("${folio.logging.request.level: FULL}") Level level) {
+    this.level = level;
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
+    if (log.isInfoEnabled()) {
+      filterWrapped(wrapRequest(request), wrapResponse(response), chain);
+    } else {
+      chain.doFilter(request, response);
+    }
+  }
+
+  private void filterWrapped(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response,
+                             FilterChain chain) throws ServletException, IOException {
+    filterBefore(request);
+    chain.doFilter(request, response);
+    filterAfter(request, response);
+    response.copyBodyToResponse();
+  }
+
+  private void filterBefore(ContentCachingRequestWrapper request) throws UnsupportedEncodingException {
+    request.setAttribute(START_TIME_ATTR, Instant.now().toEpochMilli());
+
+    var requestId = getRequestId(request);
+
+    log.info("[{}] ---> {} {} {}",
+      requestId,
+      request.getMethod(),
+      request.getRequestURI(),
+      request.getQueryString()
+    );
+
+    if (level.ordinal() >= Level.HEADERS.ordinal()) {
+      var headerNames = request.getHeaderNames();
+      while (headerNames.hasMoreElements()) {
+        var headerName = headerNames.nextElement();
+        log.info("[{}] {}: {}", requestId, headerName, request.getHeader(headerName));
+      }
+    }
+
+    if (level.ordinal() == Level.FULL.ordinal()) {
+      var body = new String(request.getContentAsByteArray(), request.getCharacterEncoding());
+      log.info("[{}] {}", requestId, body);
+    }
+
+    log.info("[{}] ---> END HTTP", requestId);
+  }
+
+  private void filterAfter(ContentCachingRequestWrapper request, ContentCachingResponseWrapper response)
+    throws UnsupportedEncodingException {
+    var startTime = (long) request.getAttribute(START_TIME_ATTR);
+    var requestId = getRequestId(request);
+
+    log.info("[{}] <--- {} in {}ms",
+      requestId,
+      response.getStatus(),
+      (Instant.now().toEpochMilli() - startTime)
+    );
+
+    if (level.ordinal() == Level.FULL.ordinal()) {
+      var body = new String(response.getContentAsByteArray(), response.getCharacterEncoding());
+      log.info("[{}] {}", requestId, body);
+    }
+
+    log.info("[{}] <--- END HTTP", requestId);
+  }
+
+  private ContentCachingResponseWrapper wrapResponse(ServletResponse response) {
+    return new ContentCachingResponseWrapper((HttpServletResponse) response);
+  }
+
+  private ContentCachingRequestWrapper wrapRequest(ServletRequest request) {
+    return new ContentCachingRequestWrapper((HttpServletRequest) request);
+  }
+
+  private String getRequestId(ContentCachingRequestWrapper request) {
+    return request.getHeader(XOkapiHeaders.REQUEST_ID);
+  }
+
+  enum Level {
+    NONE,
+    BASIC,
+    HEADERS,
+    FULL
+  }
+
+}

--- a/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
+++ b/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
@@ -78,7 +78,7 @@ public class LoggingRequestFilter extends GenericFilterBean {
 
     if (level.ordinal() == Level.FULL.ordinal()) {
       var body = new String(request.getContentAsByteArray(), request.getCharacterEncoding());
-      log.info("[{}] {}", requestId, body);
+      log.info("[{}] Body: {}", requestId, body);
     }
 
     log.info("[{}] ---> END HTTP", requestId);
@@ -97,7 +97,7 @@ public class LoggingRequestFilter extends GenericFilterBean {
 
     if (level.ordinal() == Level.FULL.ordinal()) {
       var body = new String(response.getContentAsByteArray(), response.getCharacterEncoding());
-      log.info("[{}] {}", requestId, body);
+      log.info("[{}] Body: {}", requestId, body);
     }
 
     log.info("[{}] <--- END HTTP", requestId);

--- a/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
+++ b/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
@@ -15,11 +15,11 @@ import lombok.extern.log4j.Log4j2;
 import org.apache.commons.io.IOUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.filter.OrderedFilter;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 import org.springframework.web.util.ContentCachingResponseWrapper;
 
-import org.folio.spring.integration.XOkapiHeaders;
 import org.folio.spring.utils.MultiReadHttpServletRequestWrapper;
 
 @Log4j2
@@ -29,11 +29,11 @@ import org.folio.spring.utils.MultiReadHttpServletRequestWrapper;
   name = "enabled",
   havingValue = "true"
 )
-public class LoggingRequestFilter extends GenericFilterBean {
+public class LoggingRequestFilter extends GenericFilterBean implements OrderedFilter {
 
   private static final String START_TIME_ATTR = "startTime";
-
   private final Level level;
+  private int order = REQUEST_WRAPPER_FILTER_MAX_ORDER + 3;
 
   public LoggingRequestFilter(@Value("${folio.logging.request.level: FULL}") Level level) {
     this.level = level;
@@ -49,6 +49,14 @@ public class LoggingRequestFilter extends GenericFilterBean {
     }
   }
 
+  @Override public int getOrder() {
+    return order;
+  }
+
+  private void setOrder(int order) {
+    this.order = order;
+  }
+
   private void filterWrapped(MultiReadHttpServletRequestWrapper request, ContentCachingResponseWrapper response,
                              FilterChain chain) throws ServletException, IOException {
     filterBefore(request);
@@ -60,10 +68,7 @@ public class LoggingRequestFilter extends GenericFilterBean {
   private void filterBefore(MultiReadHttpServletRequestWrapper request) throws IOException {
     request.setAttribute(START_TIME_ATTR, Instant.now().toEpochMilli());
 
-    var requestId = getRequestId(request);
-
-    log.info("[{}] ---> {} {} {}",
-      requestId,
+    log.info("---> {} {} {}",
       request.getMethod(),
       request.getRequestURI(),
       request.getQueryString()
@@ -73,35 +78,33 @@ public class LoggingRequestFilter extends GenericFilterBean {
       var headerNames = request.getHeaderNames();
       while (headerNames.hasMoreElements()) {
         var headerName = headerNames.nextElement();
-        log.info("[{}] {}: {}", requestId, headerName, request.getHeader(headerName));
+        log.info("{}: {}", headerName, request.getHeader(headerName));
       }
     }
 
     if (level.ordinal() == Level.FULL.ordinal()) {
       var body = IOUtils.toString(request.getInputStream(), request.getCharacterEncoding());
-      log.info("[{}] Body: {}", requestId, body);
+      log.info("Body: {}", body);
     }
 
-    log.info("[{}] ---> END HTTP", requestId);
+    log.info("---> END HTTP");
   }
 
   private void filterAfter(MultiReadHttpServletRequestWrapper request, ContentCachingResponseWrapper response)
     throws UnsupportedEncodingException {
     var startTime = (long) request.getAttribute(START_TIME_ATTR);
-    var requestId = getRequestId(request);
 
-    log.info("[{}] <--- {} in {}ms",
-      requestId,
+    log.info("<--- {} in {}ms",
       response.getStatus(),
       (Instant.now().toEpochMilli() - startTime)
     );
 
     if (level.ordinal() == Level.FULL.ordinal()) {
       var body = new String(response.getContentAsByteArray(), response.getCharacterEncoding());
-      log.info("[{}] Body: {}", requestId, body);
+      log.info("Body: {}", body);
     }
 
-    log.info("[{}] <--- END HTTP", requestId);
+    log.info("<--- END HTTP");
   }
 
   private ContentCachingResponseWrapper wrapResponse(ServletResponse response) {
@@ -110,10 +113,6 @@ public class LoggingRequestFilter extends GenericFilterBean {
 
   private MultiReadHttpServletRequestWrapper wrapRequest(ServletRequest request) {
     return new MultiReadHttpServletRequestWrapper((HttpServletRequest) request);
-  }
-
-  private String getRequestId(MultiReadHttpServletRequestWrapper request) {
-    return request.getHeader(XOkapiHeaders.REQUEST_ID);
   }
 
   enum Level {

--- a/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
+++ b/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
@@ -32,10 +32,12 @@ import org.folio.spring.utils.MultiReadHttpServletRequestWrapper;
 public class LoggingRequestFilter extends GenericFilterBean implements OrderedFilter {
 
   private static final String START_TIME_ATTR = "startTime";
+
   private final Level level;
+
   private int order = REQUEST_WRAPPER_FILTER_MAX_ORDER + 3;
 
-  public LoggingRequestFilter(@Value("${folio.logging.request.level: FULL}") Level level) {
+  public LoggingRequestFilter(@Value("${folio.logging.request.level: BASIC}") Level level) {
     this.level = level;
   }
 
@@ -88,7 +90,9 @@ public class LoggingRequestFilter extends GenericFilterBean implements OrderedFi
       log.info("Body: {}", body);
     }
 
-    log.info("---> END HTTP");
+    if (level.ordinal() > Level.BASIC.ordinal()) {
+      log.info("---> END HTTP");
+    }
   }
 
   private void filterAfter(MultiReadHttpServletRequestWrapper request, ContentCachingResponseWrapper response)
@@ -103,9 +107,8 @@ public class LoggingRequestFilter extends GenericFilterBean implements OrderedFi
     if (level.ordinal() == Level.FULL.ordinal()) {
       var body = new String(response.getContentAsByteArray(), response.getCharacterEncoding());
       log.info("Body: {}", body);
+      log.info("<--- END HTTP");
     }
-
-    log.info("<--- END HTTP");
   }
 
   private ContentCachingResponseWrapper wrapResponse(ServletResponse response) {

--- a/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
+++ b/src/main/java/org/folio/spring/filter/LoggingRequestFilter.java
@@ -49,11 +49,12 @@ public class LoggingRequestFilter extends GenericFilterBean implements OrderedFi
     }
   }
 
-  @Override public int getOrder() {
+  @Override
+  public int getOrder() {
     return order;
   }
 
-  private void setOrder(int order) {
+  public void setOrder(int order) {
     this.order = order;
   }
 

--- a/src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java
+++ b/src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java
@@ -1,33 +1,40 @@
 package org.folio.spring.filter;
 
-import org.apache.commons.lang3.StringUtils;
-import org.folio.spring.integration.XOkapiHeaders;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.stereotype.Component;
-import org.springframework.web.filter.GenericFilterBean;
+import java.io.IOException;
+import java.util.Arrays;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.util.Arrays;
+
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.filter.OrderedFilter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.GenericFilterBean;
+
+import org.folio.spring.integration.XOkapiHeaders;
 
 @Component("defaultTenantOkapiHeaderValidationFilter")
 @ConditionalOnMissingBean(name = "tenantOkapiHeaderValidationFilter")
 @ConditionalOnProperty(prefix = "folio.tenant.validation", name = "enabled", matchIfMissing = true)
-public class TenantOkapiHeaderValidationFilter extends GenericFilterBean {
+public class TenantOkapiHeaderValidationFilter extends GenericFilterBean implements OrderedFilter {
 
   public static final String ERROR_MSG = XOkapiHeaders.TENANT + " header must be provided";
+
+  private int order = REQUEST_WRAPPER_FILTER_MAX_ORDER + 1;
 
   @Value("${header.validation.x-okapi-tenant.exclude.base-paths:/admin}")
   private String[] excludeBasePaths;
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
     HttpServletRequest req = (HttpServletRequest) request;
     if (StringUtils.isNotBlank(req.getHeader(XOkapiHeaders.TENANT)) || Arrays.stream(excludeBasePaths)
       .anyMatch(req.getRequestURI()::startsWith)) {
@@ -38,5 +45,14 @@ public class TenantOkapiHeaderValidationFilter extends GenericFilterBean {
       res.setStatus(HttpServletResponse.SC_BAD_REQUEST);
       res.getWriter().println(ERROR_MSG);
     }
+  }
+
+  @Override
+  public int getOrder() {
+    return order;
+  }
+
+  private void setOrder(int order) {
+    this.order = order;
   }
 }

--- a/src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java
+++ b/src/main/java/org/folio/spring/filter/TenantOkapiHeaderValidationFilter.java
@@ -52,7 +52,7 @@ public class TenantOkapiHeaderValidationFilter extends GenericFilterBean impleme
     return order;
   }
 
-  private void setOrder(int order) {
+  public void setOrder(int order) {
     this.order = order;
   }
 }

--- a/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
+++ b/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
@@ -6,7 +6,10 @@ import org.apache.logging.log4j.LogManager;
 
 import org.folio.spring.FolioExecutionContext;
 
-public class FolioLoggingContextHolder {
+public final class FolioLoggingContextHolder {
+
+  private FolioLoggingContextHolder() {
+  }
 
   private static final String FOLIO_EXECUTION_CONTEXT_KEY = "FolioExecutionContext";
 

--- a/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
+++ b/src/main/java/org/folio/spring/logging/FolioLoggingContextHolder.java
@@ -1,0 +1,24 @@
+package org.folio.spring.logging;
+
+import java.util.Optional;
+
+import org.apache.logging.log4j.LogManager;
+
+import org.folio.spring.FolioExecutionContext;
+
+public class FolioLoggingContextHolder {
+
+  private static final String FOLIO_EXECUTION_CONTEXT_KEY = "FolioExecutionContext";
+
+  public static void putFolioExecutionContext(FolioExecutionContext folioExecutionContext) {
+    LogManager.getContext().putObject(FOLIO_EXECUTION_CONTEXT_KEY, folioExecutionContext);
+  }
+
+  public static void removeFolioExecutionContext() {
+    LogManager.getContext().removeObject(FOLIO_EXECUTION_CONTEXT_KEY);
+  }
+
+  public static Optional<FolioExecutionContext> getFolioExecutionContext() {
+    return Optional.ofNullable(((FolioExecutionContext) LogManager.getContext().getObject(FOLIO_EXECUTION_CONTEXT_KEY)));
+  }
+}

--- a/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
+++ b/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
@@ -1,0 +1,62 @@
+package org.folio.spring.logging;
+
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.lookup.StrLookup;
+
+import org.folio.spring.FolioExecutionContext;
+
+@Plugin(name = "folio", category = StrLookup.CATEGORY)
+public class FolioLoggingContextLookup implements StrLookup {
+
+  private static final String TENANT_ID_LOGGING_VAR_NAME = "tenantid";
+  private static final String REQUEST_ID_LOGGING_VAR_NAME = "requestid";
+  private static final String MODULE_ID_LOGGING_VAR_NAME = "moduleid";
+  private static final String USER_ID_LOGGING_VAR_NAME = "userid";
+
+  private static final Map<String, Function<FolioExecutionContext, String>> map = new HashMap<>();
+
+  static {
+    map.put(TENANT_ID_LOGGING_VAR_NAME, FolioExecutionContext::getTenantId);
+    map.put(USER_ID_LOGGING_VAR_NAME, context -> context.getUserId() == null ? EMPTY : context.getUserId().toString());
+    map.put(MODULE_ID_LOGGING_VAR_NAME, context -> context.getFolioModuleMetadata().getModuleName());
+    map.put(REQUEST_ID_LOGGING_VAR_NAME, FolioExecutionContext::getRequestId);
+  }
+
+  /**
+   * Lookup value by key.
+   *
+   * @param key the name of logging variable, {@code null} key isn't allowed
+   * @return value for key or *empty string* if there is no such key
+   */
+  @Override
+  public String lookup(String key) {
+    return lookup(null, key);
+  }
+
+  /**
+   * Lookup value by key. LogEvent isn't used.
+   *
+   * @param key the name of logging variable, {@code null} key isn't allowed
+   * @return value for key or *empty string* if there is no such key
+   */
+  @Override
+  public String lookup(LogEvent event, String key) {
+    var folioExecutionContext = FolioLoggingContextHolder.getFolioExecutionContext();
+    if (folioExecutionContext.isEmpty()) {
+      return EMPTY;
+    }
+    if (key == null) {
+      throw new IllegalArgumentException("Key cannot be null");
+    }
+    return map.getOrDefault(key, c -> EMPTY).apply(folioExecutionContext.get());
+  }
+
+}

--- a/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
+++ b/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.plugins.Plugin;
 import org.apache.logging.log4j.core.lookup.StrLookup;

--- a/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
+++ b/src/main/java/org/folio/spring/logging/FolioLoggingContextLookup.java
@@ -49,12 +49,12 @@ public class FolioLoggingContextLookup implements StrLookup {
    */
   @Override
   public String lookup(LogEvent event, String key) {
+    if (key == null) {
+      throw new IllegalArgumentException("Key cannot be null");
+    }
     var folioExecutionContext = FolioLoggingContextHolder.getFolioExecutionContext();
     if (folioExecutionContext.isEmpty()) {
       return EMPTY;
-    }
-    if (key == null) {
-      throw new IllegalArgumentException("Key cannot be null");
     }
     return map.getOrDefault(key, c -> EMPTY).apply(folioExecutionContext.get());
   }

--- a/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
+++ b/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
@@ -3,6 +3,9 @@ package org.folio.spring.scope;
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.logging.FolioLoggingContextHolder;
+
+import org.apache.logging.log4j.LogManager;
 import org.springframework.core.NamedInheritableThreadLocal;
 
 import java.util.Map;
@@ -29,11 +32,13 @@ public class FolioExecutionScopeExecutionContextManager {
     scopeMap.put(CONVERSATION_ID_KEY, UUID.randomUUID().toString());
     folioExecutionScopeHolder.set(scopeMap);
     folioExecutionContextHolder.set(folioExecutionContext);
+    FolioLoggingContextHolder.putFolioExecutionContext(folioExecutionContext);
   }
 
   public static void endFolioExecutionContext() {
     folioExecutionContextHolder.remove();
     folioExecutionScopeHolder.remove();
+    FolioLoggingContextHolder.removeFolioExecutionContext();
   }
 
   static FolioExecutionContext getFolioExecutionContext() {

--- a/src/main/java/org/folio/spring/scope/filter/FolioExecutionScopeFilter.java
+++ b/src/main/java/org/folio/spring/scope/filter/FolioExecutionScopeFilter.java
@@ -49,7 +49,7 @@ public class FolioExecutionScopeFilter extends GenericFilterBean implements Orde
     return order;
   }
 
-  private void setOrder(int order) {
+  public void setOrder(int order) {
     this.order = order;
   }
 }

--- a/src/main/java/org/folio/spring/scope/filter/FolioExecutionScopeFilter.java
+++ b/src/main/java/org/folio/spring/scope/filter/FolioExecutionScopeFilter.java
@@ -1,30 +1,37 @@
 package org.folio.spring.scope.filter;
 
-import lombok.extern.log4j.Log4j2;
-import org.folio.spring.DefaultFolioExecutionContext;
-import org.folio.spring.FolioModuleMetadata;
-import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
-import org.springframework.web.filter.GenericFilterBean;
+import static org.folio.spring.utils.RequestUtils.getHttpHeadersFromRequest;
+
+import java.io.IOException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
-import java.io.IOException;
 
-import static org.folio.spring.utils.RequestUtils.getHttpHeadersFromRequest;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.boot.web.servlet.filter.OrderedFilter;
+import org.springframework.web.filter.GenericFilterBean;
+
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.folio.spring.scope.FolioExecutionScopeExecutionContextManager;
 
 @Log4j2
-public class FolioExecutionScopeFilter extends GenericFilterBean {
+public class FolioExecutionScopeFilter extends GenericFilterBean implements OrderedFilter {
+
   private final FolioModuleMetadata folioModuleMetadata;
+
+  private int order = REQUEST_WRAPPER_FILTER_MAX_ORDER + 2;
 
   public FolioExecutionScopeFilter(FolioModuleMetadata folioModuleMetadata) {
     this.folioModuleMetadata = folioModuleMetadata;
   }
 
   @Override
-  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+    throws IOException, ServletException {
     if (request instanceof HttpServletRequest) {
       var httpHeaders = getHttpHeadersFromRequest((HttpServletRequest) request);
       var defaultFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, httpHeaders);
@@ -37,5 +44,12 @@ public class FolioExecutionScopeFilter extends GenericFilterBean {
     }
   }
 
+  @Override
+  public int getOrder() {
+    return order;
+  }
 
+  private void setOrder(int order) {
+    this.order = order;
+  }
 }

--- a/src/main/java/org/folio/spring/utils/MultiReadHttpServletRequestWrapper.java
+++ b/src/main/java/org/folio/spring/utils/MultiReadHttpServletRequestWrapper.java
@@ -1,0 +1,71 @@
+package org.folio.spring.utils;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import javax.servlet.ReadListener;
+import javax.servlet.ServletInputStream;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+
+import org.apache.commons.io.IOUtils;
+
+public class MultiReadHttpServletRequestWrapper extends HttpServletRequestWrapper {
+
+  private ByteArrayOutputStream cachedBytes;
+
+  public MultiReadHttpServletRequestWrapper(HttpServletRequest request) {
+    super(request);
+  }
+
+  @Override
+  public ServletInputStream getInputStream() throws IOException {
+    if (cachedBytes == null)
+      cacheInputStream();
+
+    return new CachedServletInputStream(cachedBytes.toByteArray());
+  }
+
+  @Override
+  public BufferedReader getReader() throws IOException {
+    return new BufferedReader(new InputStreamReader(getInputStream()));
+  }
+
+  private void cacheInputStream() throws IOException {
+    cachedBytes = new ByteArrayOutputStream();
+    IOUtils.copy(super.getInputStream(), cachedBytes);
+  }
+
+  private static class CachedServletInputStream extends ServletInputStream {
+
+    private final ByteArrayInputStream buffer;
+
+    public CachedServletInputStream(byte[] contents) {
+      this.buffer = new ByteArrayInputStream(contents);
+    }
+
+    @Override
+    public int read() {
+      return buffer.read();
+    }
+
+    @Override
+    public boolean isFinished() {
+      return buffer.available() == 0;
+    }
+
+    @Override
+    public boolean isReady() {
+      return true;
+    }
+
+    @Override
+    public void setReadListener(ReadListener listener) {
+      throw new RuntimeException("Not implemented");
+    }
+  }
+}
+

--- a/src/main/java/org/folio/spring/utils/MultiReadHttpServletRequestWrapper.java
+++ b/src/main/java/org/folio/spring/utils/MultiReadHttpServletRequestWrapper.java
@@ -12,6 +12,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.NotImplementedException;
 
 public class MultiReadHttpServletRequestWrapper extends HttpServletRequestWrapper {
 
@@ -64,7 +65,7 @@ public class MultiReadHttpServletRequestWrapper extends HttpServletRequestWrappe
 
     @Override
     public void setReadListener(ReadListener listener) {
-      throw new RuntimeException("Not implemented");
+      throw new NotImplementedException("Not implemented");
     }
   }
 }

--- a/src/main/resources/log4j2-json.properties
+++ b/src/main/resources/log4j2-json.properties
@@ -1,0 +1,37 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.spring.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = JSONLayout
+appender.console.layout.compact = true
+appender.console.layout.eventEol = true
+appender.console.layout.stacktraceAsString = true
+
+appender.console.layout.requestId.type = KeyValuePair
+appender.console.layout.requestId.key = requestId
+appender.console.layout.requestId.value = $${folio:requestid}
+
+appender.console.layout.tenantId.type = KeyValuePair
+appender.console.layout.tenantId.key = tenantId
+appender.console.layout.tenantId.value = $${folio:tenantid}
+
+appender.console.layout.userId.type = KeyValuePair
+appender.console.layout.userId.key = userId
+appender.console.layout.userId.value = $${folio:userid}
+
+appender.console.layout.moduleId.type = KeyValuePair
+appender.console.layout.moduleId.key = moduleId
+appender.console.layout.moduleId.value = $${folio:moduleid}
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -1,0 +1,20 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.spring.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} [$${folio:requestid}] [$${folio:tenantid}] [$${folio:userid}] [$${folio:moduleid}] %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/test/java/org/folio/spring/DefaultFolioExecutionContextTest.java
+++ b/src/test/java/org/folio/spring/DefaultFolioExecutionContextTest.java
@@ -3,6 +3,7 @@ package org.folio.spring;
 import static java.util.Collections.singleton;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
 import static org.folio.spring.integration.XOkapiHeaders.TENANT;
 import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
 import static org.folio.spring.integration.XOkapiHeaders.URL;
@@ -32,6 +33,7 @@ class DefaultFolioExecutionContextTest {
   @Test
   void testExtractionFromHeadersWhenAllNeededHeadersExists() {
     var userId = "ad162b38-1291-4437-8948-9d13eeced9f6";
+    var requestId = "heL9F";
     var token = "valid-token";
     var tenant = "tenant";
     var url = "http://okapi.com";
@@ -41,6 +43,7 @@ class DefaultFolioExecutionContextTest {
     headers.put(URL, singleton(url));
     headers.put(TOKEN, singleton(token));
     headers.put(USER_ID, singleton(userId));
+    headers.put(REQUEST_ID, singleton(requestId));
     headers.put("Accept", singleton("application/json"));
 
     var actual = new DefaultFolioExecutionContext(moduleMetadata, headers);
@@ -48,11 +51,12 @@ class DefaultFolioExecutionContextTest {
     Consumer<DefaultFolioExecutionContext> contextRequirements = context -> {
       assertThat(context.getFolioModuleMetadata()).isEqualTo(moduleMetadata);
       assertThat(context.getAllHeaders()).isEqualTo(headers);
-      assertThat(context.getOkapiHeaders()).containsOnlyKeys(TENANT, URL, TOKEN, USER_ID);
+      assertThat(context.getOkapiHeaders()).containsOnlyKeys(TENANT, URL, TOKEN, USER_ID, REQUEST_ID);
       assertThat(context.getOkapiUrl()).isEqualTo(url);
       assertThat(context.getToken()).isEqualTo(token);
       assertThat(context.getTenantId()).isEqualTo(tenant);
       assertThat(context.getUserId()).isEqualTo(UUID.fromString(userId));
+      assertThat(context.getRequestId()).isEqualTo(requestId);
     };
 
     assertThat(actual).satisfies(contextRequirements);

--- a/src/test/java/org/folio/spring/FolioExecutionContextTest.java
+++ b/src/test/java/org/folio/spring/FolioExecutionContextTest.java
@@ -16,6 +16,7 @@ class FolioExecutionContextTest {
       assertNull(ctx.getOkapiUrl());
       assertNull(ctx.getToken());
       assertNull(ctx.getUserId());
+      assertNull(ctx.getRequestId());
       assertNull(ctx.getAllHeaders());
       assertNull(ctx.getOkapiHeaders());
       assertNull(ctx.getFolioModuleMetadata());

--- a/src/test/java/org/folio/spring/config/FeignInfoLoggerTest.java
+++ b/src/test/java/org/folio/spring/config/FeignInfoLoggerTest.java
@@ -1,0 +1,25 @@
+package org.folio.spring.config;
+
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.Logger;
+
+@ExtendWith(MockitoExtension.class)
+class FeignInfoLoggerTest {
+
+  @Mock
+  private Logger mockLogger;
+
+  @Test
+  void testLog() {
+    var logger = new FeignClientConfiguration.FeignInfoLogger(mockLogger);
+    logger.log("test(Key)", "Test %s message", "log");
+
+    verify(mockLogger).info("[test] Test log message");
+  }
+
+}

--- a/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
+++ b/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
@@ -152,7 +152,7 @@ class LoggingRequestFilterTest {
     filter.setOrder(0);
     var actualOrder = filter.getOrder();
 
-    assertThat(actualOrder).isEqualTo(0);
+    assertThat(actualOrder).isZero();
   }
 
   private Consumer<String> requestInfo() {

--- a/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
+++ b/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
@@ -1,0 +1,154 @@
+package org.folio.spring.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.data.Index.atIndex;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Consumer;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+import org.folio.spring.filter.appender.TestAppender;
+import org.folio.spring.integration.XOkapiHeaders;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class LoggingRequestFilterTest {
+
+  private static final String TEST_METHOD = "GET";
+  private static final String TEST_URI = "/test-uri";
+  private static final String TEST_QUERY = "param=true";
+  private static final String TEST_REQUEST_ID = "10101";
+  private static final int TEST_STATUS = 200;
+  private static final String TEST_TOKEN = "test-token";
+
+  @Mock
+  private HttpServletRequest servletRequest;
+  @Mock
+  private HttpServletResponse servletResponse;
+  @Mock
+  private FilterChain filterChain;
+
+  private TestAppender testAppender;
+
+  @BeforeEach
+  void setUp() {
+    Map<String, String> testHeaders = new HashMap<>();
+    testHeaders.put(XOkapiHeaders.REQUEST_ID, TEST_REQUEST_ID);
+    testHeaders.put(XOkapiHeaders.TOKEN, TEST_TOKEN);
+
+    when(servletRequest.getAttribute(anyString())).thenReturn(Instant.now().toEpochMilli());
+    when(servletRequest.getMethod()).thenReturn(TEST_METHOD);
+    when(servletRequest.getRequestURI()).thenReturn(TEST_URI);
+    when(servletRequest.getQueryString()).thenReturn(TEST_QUERY);
+    when(servletRequest.getHeader(XOkapiHeaders.REQUEST_ID)).thenReturn(TEST_REQUEST_ID);
+    when(servletResponse.getStatus()).thenReturn(TEST_STATUS);
+    when(servletRequest.getHeaderNames()).thenReturn(Collections.enumeration(testHeaders.keySet()));
+    when(servletRequest.getHeader(XOkapiHeaders.REQUEST_ID)).thenReturn(TEST_REQUEST_ID);
+    when(servletRequest.getHeader(XOkapiHeaders.TOKEN)).thenReturn(TEST_TOKEN);
+    when(servletResponse.getCharacterEncoding()).thenReturn("UTF-8");
+    when(servletRequest.getCharacterEncoding()).thenReturn("UTF-8");
+
+    final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+    final Configuration config = ctx.getConfiguration();
+    testAppender = (TestAppender) config.getAppenders().get("TestAppender");
+  }
+
+  @AfterEach
+  void tearDown() {
+    testAppender.clearMessages();
+  }
+
+  @Test
+  void basicLoggingTest() throws ServletException, IOException {
+    var filter = new LoggingRequestFilter(LoggingRequestFilter.Level.BASIC);
+    filter.doFilter(servletRequest, servletResponse, filterChain);
+
+    assertThat(testAppender.getMessages())
+      .hasSize(4)
+      .extracting(logEvent -> logEvent.getMessage().getFormattedMessage())
+      .satisfies(requestInfo(), atIndex(0))
+      .satisfies(requestEndHttp(), atIndex(1))
+      .satisfies(responseStatusWithTime(), atIndex(2))
+      .satisfies(responseEndHttp(), atIndex(3));
+  }
+
+  @Test
+  void headersLoggingTest() throws ServletException, IOException {
+    var filter = new LoggingRequestFilter(LoggingRequestFilter.Level.HEADERS);
+    filter.doFilter(servletRequest, servletResponse, filterChain);
+
+    assertThat(testAppender.getMessages())
+      .hasSize(6)
+      .extracting(logEvent -> logEvent.getMessage().getFormattedMessage())
+      .satisfies(requestInfo(), atIndex(0))
+      .satisfies(requestHeader(XOkapiHeaders.TOKEN, TEST_TOKEN), atIndex(1))
+      .satisfies(requestHeader(XOkapiHeaders.REQUEST_ID, TEST_REQUEST_ID), atIndex(2))
+      .satisfies(requestEndHttp(), atIndex(3))
+      .satisfies(responseStatusWithTime(), atIndex(4))
+      .satisfies(responseEndHttp(), atIndex(5));
+  }
+
+  @Test
+  void fullLoggingTest() throws ServletException, IOException {
+    var filter = new LoggingRequestFilter(LoggingRequestFilter.Level.FULL);
+    filter.doFilter(servletRequest, servletResponse, filterChain);
+
+    assertThat(testAppender.getMessages())
+      .hasSize(8)
+      .extracting(logEvent -> logEvent.getMessage().getFormattedMessage())
+      .satisfies(requestInfo(), atIndex(0))
+      .satisfies(requestHeader(XOkapiHeaders.TOKEN, TEST_TOKEN), atIndex(1))
+      .satisfies(requestHeader(XOkapiHeaders.REQUEST_ID, TEST_REQUEST_ID), atIndex(2))
+      .satisfies(body(), atIndex(3))
+      .satisfies(requestEndHttp(), atIndex(4))
+      .satisfies(responseStatusWithTime(), atIndex(5))
+      .satisfies(body(), atIndex(6))
+      .satisfies(responseEndHttp(), atIndex(7));
+  }
+
+  private Consumer<String> requestInfo() {
+    return s -> assertThat(s).isEqualTo("[" + TEST_REQUEST_ID + "] ---> " + TEST_METHOD + " " + TEST_URI + " " + TEST_QUERY);
+  }
+
+  private Consumer<String> requestHeader(String headerName, String headerValue) {
+    return s -> assertThat(s).isEqualTo("[" + TEST_REQUEST_ID + "] " + headerName + ": " + headerValue);
+  }
+
+  private Consumer<String> responseStatusWithTime() {
+    return s -> assertThat(s).matches("\\[" + TEST_REQUEST_ID + "] <--- " + TEST_STATUS + " in \\d+ms");
+  }
+
+  private Consumer<String> body() {
+    return s -> assertThat(s).isEqualTo("[" + TEST_REQUEST_ID + "] Body: ");
+  }
+
+  private Consumer<String> requestEndHttp() {
+    return s -> assertThat(s).isEqualTo("[" + TEST_REQUEST_ID + "] ---> END HTTP");
+  }
+
+  private Consumer<String> responseEndHttp() {
+    return s -> assertThat(s).isEqualTo("[" + TEST_REQUEST_ID + "] <--- END HTTP");
+  }
+}

--- a/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
+++ b/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
@@ -22,7 +22,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
+++ b/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
@@ -95,12 +95,10 @@ class LoggingRequestFilterTest {
     filter.doFilter(servletRequest, servletResponse, filterChain);
 
     assertThat(testAppender.getMessages())
-      .hasSize(4)
+      .hasSize(2)
       .extracting(logEvent -> logEvent.getMessage().getFormattedMessage())
       .satisfies(requestInfo(), atIndex(0))
-      .satisfies(requestEndHttp(), atIndex(1))
-      .satisfies(responseStatusWithTime(), atIndex(2))
-      .satisfies(responseEndHttp(), atIndex(3));
+      .satisfies(responseStatusWithTime(), atIndex(1));
   }
 
   @Test
@@ -109,14 +107,13 @@ class LoggingRequestFilterTest {
     filter.doFilter(servletRequest, servletResponse, filterChain);
 
     assertThat(testAppender.getMessages())
-      .hasSize(6)
+      .hasSize(5)
       .extracting(logEvent -> logEvent.getMessage().getFormattedMessage())
       .satisfies(requestInfo(), atIndex(0))
       .satisfies(requestHeader(XOkapiHeaders.TOKEN, TEST_TOKEN), atIndex(1))
       .satisfies(requestHeader(XOkapiHeaders.REQUEST_ID, TEST_REQUEST_ID), atIndex(2))
       .satisfies(requestEndHttp(), atIndex(3))
-      .satisfies(responseStatusWithTime(), atIndex(4))
-      .satisfies(responseEndHttp(), atIndex(5));
+      .satisfies(responseStatusWithTime(), atIndex(4));
   }
 
   @Test

--- a/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
+++ b/src/test/java/org/folio/spring/filter/LoggingRequestFilterTest.java
@@ -20,7 +20,6 @@ import javax.servlet.http.HttpServletResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -73,10 +72,6 @@ class LoggingRequestFilterTest {
     final LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
     final Configuration config = ctx.getConfiguration();
     testAppender = (TestAppender) config.getAppenders().get("TestAppender");
-  }
-
-  @AfterEach
-  void tearDown() {
     testAppender.clearMessages();
   }
 

--- a/src/test/java/org/folio/spring/filter/appender/TestAppender.java
+++ b/src/test/java/org/folio/spring/filter/appender/TestAppender.java
@@ -1,0 +1,52 @@
+package org.folio.spring.filter.appender;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.Getter;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Property;
+import org.apache.logging.log4j.core.config.plugins.Plugin;
+import org.apache.logging.log4j.core.config.plugins.PluginAttribute;
+import org.apache.logging.log4j.core.config.plugins.PluginElement;
+import org.apache.logging.log4j.core.config.plugins.PluginFactory;
+import org.apache.logging.log4j.core.layout.PatternLayout;
+
+@Plugin(name = "TestAppender", category = "Core", elementType = "appender", printObject = true)
+public class TestAppender extends AbstractAppender {
+
+  @Getter
+  private final List<LogEvent> messages = new ArrayList<>();
+
+  protected TestAppender(String name, Filter filter, Layout<? extends Serializable> layout) {
+    super(name, filter, layout, true, Property.EMPTY_ARRAY);
+  }
+
+  @PluginFactory
+  public static TestAppender createAppender(@PluginAttribute("name") String name,
+                                            @PluginElement("Layout") Layout<? extends Serializable> layout,
+                                            @PluginElement("Filter") final Filter filter,
+                                            @PluginAttribute("otherAttribute") String otherAttribute) {
+    if (name == null) {
+      LOGGER.error("No name provided for TestAppender");
+      return null;
+    }
+    if (layout == null) {
+      layout = PatternLayout.createDefaultLayout();
+    }
+    return new TestAppender(name, filter, layout);
+  }
+
+  public void clearMessages() {
+    messages.clear();
+  }
+
+  @Override
+  public void append(LogEvent event) {
+    messages.add(event);
+  }
+}

--- a/src/test/java/org/folio/spring/logging/FolioLoggingContextLookupTest.java
+++ b/src/test/java/org/folio/spring/logging/FolioLoggingContextLookupTest.java
@@ -1,0 +1,108 @@
+package org.folio.spring.logging;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+
+@ExtendWith(MockitoExtension.class)
+class FolioLoggingContextLookupTest {
+
+  private static final String TEST_TENANT = "test";
+  private static final String TEST_USER_ID = "af51421f-72bb-4672-ac6d-f933c7bc3fbd";
+  private static final String TEST_REQUEST_ID = "614";
+  private static final String TEST_MOD_ID = "mod-test";
+  private final FolioLoggingContextLookup contextLookup = new FolioLoggingContextLookup();
+
+  @BeforeEach
+  void setUp() {
+    FolioLoggingContextHolder.removeFolioExecutionContext();
+  }
+
+  @Test
+  void testLookupWhenContextIsEmpty() {
+    var lookupVal = contextLookup.lookup("tenantid");
+    assertEquals("", lookupVal);
+  }
+
+  @Test
+  void testLookupWhenKeyIsNull() {
+    assertThrows(IllegalArgumentException.class, () -> contextLookup.lookup(null));
+  }
+
+  @Test
+  void testLookupWhenContextNotSupportProvidedKey() {
+    var lookupVal = contextLookup.lookup("not-supported-key");
+    assertEquals("", lookupVal);
+  }
+
+  @Test
+  void testLookupForTenantId() {
+    saveFolioContext();
+    var lookupVal = contextLookup.lookup("tenantid");
+    assertEquals(TEST_TENANT, lookupVal);
+  }
+
+  @Test
+  void testLookupForUserId() {
+    saveFolioContext();
+    var lookupVal = contextLookup.lookup("userid");
+    assertEquals(TEST_USER_ID, lookupVal);
+  }
+
+  @Test
+  void testLookupForRequestId() {
+    saveFolioContext();
+    var lookupVal = contextLookup.lookup("requestid");
+    assertEquals(TEST_REQUEST_ID, lookupVal);
+  }
+
+  @Test
+  void testLookupForModuleId() {
+    saveFolioContext();
+    var lookupVal = contextLookup.lookup("moduleid");
+    assertEquals(TEST_MOD_ID, lookupVal);
+  }
+
+  private void saveFolioContext() {
+    FolioLoggingContextHolder.putFolioExecutionContext(new FolioExecutionContext() {
+
+      @Override
+      public String getTenantId() {
+        return TEST_TENANT;
+      }
+
+      @Override
+      public UUID getUserId() {
+        return UUID.fromString(TEST_USER_ID);
+      }
+
+      @Override
+      public String getRequestId() {
+        return TEST_REQUEST_ID;
+      }
+
+      @Override
+      public FolioModuleMetadata getFolioModuleMetadata() {
+        return new FolioModuleMetadata() {
+
+          @Override
+          public String getModuleName() {
+            return TEST_MOD_ID;
+          }
+
+          @Override public String getDBSchemaName(String tenantId) {
+            return null;
+          }
+        };
+      }
+    });
+  }
+}

--- a/src/test/resources/log4j2-test.xml
+++ b/src/test/resources/log4j2-test.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN" packages="org.folio.spring.filter.appender">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </Console>
+        <TestAppender name="TestAppender" >
+            <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n" />
+        </TestAppender>
+    </Appenders>
+    <Loggers>
+        <Logger name="org.folio" level="All" />
+        <Root>
+            <AppenderRef ref="Console" level="All" />
+            <AppenderRef ref="TestAppender" level="All" />
+        </Root>
+    </Loggers>
+</Configuration>


### PR DESCRIPTION
## Purpose
* Include default log4j config that's aligned with the FOLIO logging format (https://wiki.folio.org/pages/viewpage.action?pageId=36576312)
* Log requests to module and responses from it
* Log requests to other modules with feign clients.
* Have an ability to enable/disable the logging from application properties
* Have an ability to specify how detailed log should be:
  - log only request and response status
  - log all above and headers of a request
  - log all above and body of request/response
