### PR TITLE
FOLSPRINGB-25 Upgrade Spring Boot to v2.5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.3.4.RELEASE</version>
+    <version>2.5.2</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -17,16 +17,16 @@
 
   <properties>
     <java.version>11</java.version>
-    <spring-cloud-starter-openfeign.version>2.2.5.RELEASE</spring-cloud-starter-openfeign.version>
-    <commons-lang3.version>3.5</commons-lang3.version>
-    <cql2pgjson.version>33.0.0</cql2pgjson.version>
+    <spring-cloud-starter-openfeign.version>3.0.3</spring-cloud-starter-openfeign.version>
+    <commons-lang3.version>3.12.0</commons-lang3.version>
+    <cql2pgjson.version>33.0.2</cql2pgjson.version>
     <springfox-boot-starter.version>3.0.0</springfox-boot-starter.version>
-    <openapi-generator.version>4.3.1</openapi-generator.version>
-    <jackson-databind-nullable.version>0.1.0</jackson-databind-nullable.version>
-    <feign-okhttp.version>10.10.1</feign-okhttp.version>
+    <openapi-generator.version>5.2.0</openapi-generator.version>
+    <jackson-databind-nullable.version>0.2.1</jackson-databind-nullable.version>
+    <feign-okhttp.version>11.2</feign-okhttp.version>
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
     <lombok.version>1.18.16</lombok.version>
-    <mapstruct.version>1.4.1.Final</mapstruct.version>
+    <mapstruct.version>1.4.2.Final</mapstruct.version>
     <mockito.version>3.8.0</mockito.version>
     <easy-random.version>5.0.0</easy-random.version>
   </properties>
@@ -212,7 +212,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>3.0.0-M2</version>
+        <version>3.0.0-M3</version>
         <executions>
           <execution>
             <id>enforce-maven</id>
@@ -299,7 +299,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>3.0.0-M1</version>
+        <version>3.0.0-M4</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>

--- a/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
+++ b/src/main/java/org/folio/spring/cql/JpaCqlRepositoryImpl.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.support.JpaEntityInformation;
 import org.springframework.data.jpa.repository.support.SimpleJpaRepository;
 import org.springframework.data.repository.NoRepositoryBean;
-import org.springframework.data.repository.support.PageableExecutionUtils;
+import org.springframework.data.support.PageableExecutionUtils;
 
 import org.folio.spring.data.OffsetRequest;
 

--- a/src/main/java/org/folio/spring/data/OffsetRequest.java
+++ b/src/main/java/org/folio/spring/data/OffsetRequest.java
@@ -91,7 +91,7 @@ public class OffsetRequest implements Pageable {
   @Override
   @NonNull
   public Pageable withPage(int pageNumber) {
-    return new OffsetRequest(pageNumber, getPageSize(), getSort());
+    return new OffsetRequest((long) pageNumber * getPageSize(), getPageSize(), getSort());
   }
 
   @Override

--- a/src/main/java/org/folio/spring/data/OffsetRequest.java
+++ b/src/main/java/org/folio/spring/data/OffsetRequest.java
@@ -89,6 +89,12 @@ public class OffsetRequest implements Pageable {
   }
 
   @Override
+  @NonNull
+  public Pageable withPage(int pageNumber) {
+    return new OffsetRequest(pageNumber, getPageSize(), getSort());
+  }
+
+  @Override
   public boolean hasPrevious() {
     return offset > limit;
   }

--- a/src/main/java/org/folio/spring/liquibase/FolioPostgresDatabase.java
+++ b/src/main/java/org/folio/spring/liquibase/FolioPostgresDatabase.java
@@ -1,0 +1,24 @@
+package org.folio.spring.liquibase;
+
+import liquibase.database.core.PostgresDatabase;
+import liquibase.exception.DatabaseException;
+
+/**
+ * Override default behaviour that override search_path that sets in {@link org.folio.spring.config.DataSourceFolioWrapper}
+ */
+public class FolioPostgresDatabase extends PostgresDatabase {
+
+  @Override
+  public int getPriority() {
+    return super.getPriority() + 1;
+  }
+
+  @Override
+  public void rollback() throws DatabaseException {
+    try {
+      getConnection().rollback();
+    } catch (DatabaseException e) {
+      throw new DatabaseException(e);
+    }
+  }
+}

--- a/src/main/java/org/folio/spring/liquibase/FolioPostgresDatabase.java
+++ b/src/main/java/org/folio/spring/liquibase/FolioPostgresDatabase.java
@@ -4,7 +4,7 @@ import liquibase.database.core.PostgresDatabase;
 import liquibase.exception.DatabaseException;
 
 /**
- * Override default behaviour that override search_path that sets in {@link org.folio.spring.config.DataSourceFolioWrapper}
+ * Override default behaviour that change search_path was set in {@link org.folio.spring.config.DataSourceFolioWrapper}
  */
 public class FolioPostgresDatabase extends PostgresDatabase {
 

--- a/src/main/java/org/folio/spring/liquibase/FolioSpringLiquibase.java
+++ b/src/main/java/org/folio/spring/liquibase/FolioSpringLiquibase.java
@@ -1,15 +1,17 @@
 package org.folio.spring.liquibase;
 
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+
+import liquibase.database.DatabaseFactory;
 import liquibase.exception.LiquibaseException;
 import liquibase.integration.spring.SpringLiquibase;
 import lombok.extern.log4j.Log4j2;
 import org.apache.commons.lang3.StringUtils;
 
-import java.sql.SQLException;
-import java.util.regex.Pattern;
-
 @Log4j2
 public class FolioSpringLiquibase extends SpringLiquibase {
+
   private static final Pattern NON_WORD_CHARACTERS = Pattern.compile("[^a-zA-Z0-9_]");
 
   @Override
@@ -18,6 +20,7 @@ public class FolioSpringLiquibase extends SpringLiquibase {
   }
 
   public void performLiquibaseUpdate() throws LiquibaseException {
+    DatabaseFactory.getInstance().register(new FolioPostgresDatabase());
     var defaultSchema = getDefaultSchema();
     if (StringUtils.isNotBlank(defaultSchema)) {
       //DB schema name check to prevent SQL injection.

--- a/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
+++ b/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
@@ -5,7 +5,6 @@ import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.logging.FolioLoggingContextHolder;
 
-import org.apache.logging.log4j.LogManager;
 import org.springframework.core.NamedInheritableThreadLocal;
 
 import java.util.Map;

--- a/src/test/java/org/folio/spring/data/OffsetRequestTest.java
+++ b/src/test/java/org/folio/spring/data/OffsetRequestTest.java
@@ -123,6 +123,18 @@ class OffsetRequestTest {
     }
 
     @Test
+    void shouldReturnSpecifiedPage() {
+      var pageNumber = 10;
+      Pageable first = req.withPage(pageNumber);
+
+      assertEquals(new OffsetRequest(
+          (long) pageNumber * req.getPageSize(),
+          req.getPageSize(),
+          req.getSort()),
+        first);
+    }
+
+    @Test
     void shouldHavePreviousPage() {
       assertTrue(req.hasPrevious());
     }

--- a/src/test/java/org/folio/spring/liquibase/FolioPostgresDatabaseTest.java
+++ b/src/test/java/org/folio/spring/liquibase/FolioPostgresDatabaseTest.java
@@ -1,0 +1,47 @@
+package org.folio.spring.liquibase;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+
+import liquibase.database.DatabaseConnection;
+import liquibase.exception.DatabaseException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FolioPostgresDatabaseTest {
+
+  private final FolioPostgresDatabase database = new FolioPostgresDatabase();
+
+  @Mock
+  private DatabaseConnection connection;
+
+  @BeforeEach
+  void setUp() {
+    database.setConnection(connection);
+  }
+
+  @Test
+  void testPriority() {
+    var actual = database.getPriority();
+    assertEquals(2, actual);
+  }
+
+  @Test
+  void testRollbackFailedWithException() throws DatabaseException {
+    doThrow(DatabaseException.class).when(connection).rollback();
+    assertThrows(DatabaseException.class, database::rollback);
+  }
+
+  @Test
+  void testRollbackSucceed() throws DatabaseException {
+    doNothing().when(connection).rollback();
+    assertDoesNotThrow(database::rollback);
+  }
+}


### PR DESCRIPTION
## Purpose
Upgrade Spring Boot to v2.5.2

## Testing
For testing purposes, mod-quick-marc and mod-tags were upgraded to this version of folio-spring-base. No issues were found after the upgrade. 
Release notes on how to upgrade to the new version of folio-spring-base will be provided with release.

## Learning
A new version of Liquibase that comes with upgraded Spring Boot causes the issue when the migration script doesn't see database functions created in the public scheme.  
The root cause of that is setting PostgreSQL search_path to module scheme after each successful or not changeset execution. This search_path change executes in `liquibase.database.core.PostgresDatabase#rollback()` method.  

To fix this `FolioPostgresDatabase` class provided. It overrides this behavior. To make this class work instead of the default it should be registered in `liquibase.database.DatabaseFactory` and its priority should be higher than the default one. 