### PR TITLE
FOLSPRINGB-29 Kiwi R3 2021 - Log4j vulnerability verification and correction

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <mockito.version>3.8.0</mockito.version>
     <easy-random.version>5.0.0</easy-random.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version> <!-- if less then vulnerable to CVE-2021-44228 and CVE-2021-45046-->
   </properties>
 
   <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,7 @@
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <mockito.version>3.8.0</mockito.version>
     <easy-random.version>5.0.0</easy-random.version>
+    <log4j2.version>2.15.0</log4j2.version>
   </properties>
 
   <repositories>


### PR DESCRIPTION
## Purpose
Fix log4j2 `RCE` vulnerability

## Approach
- log4j2 version set to 2.16.0

## Learning
[FOLSPRINGB-29](https://issues.folio.org/browse/FOLSPRINGB-29)
[CVE-2021-44228](https://github.com/advisories/GHSA-jfh8-c2jp-5v3q)
[CVE-2021-45046](https://github.com/advisories/GHSA-7rjr-3q55-vv33)
`mvn dependency:list | grep log4j` can be used to check log4j versions used
