### PR TITLE
FOLSPRINGB-42: Spring Boot 2.6.3, log4j-core 2.17.1 (CVE-2021-44832)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.2</version>
+    <version>2.6.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -24,7 +24,6 @@
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>
     <feign-okhttp.version>11.7</feign-okhttp.version>
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
-    <lombok.version>1.18.16</lombok.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <mockito.version>3.8.0</mockito.version>
     <easy-random.version>5.0.0</easy-random.version>


### PR DESCRIPTION
Update Spring Boot from 2.6.2 to 2.6.3.

This indirectly updates log4j-core from 2.17.0 to 2.17.1 fixing a remote code execution vulnerability: https://nvd.nist.gov/vuln/detail/CVE-2021-44832