### PR TITLE
FOLSPRINGB-51: Spring Boot 2.6.7, Liquibase 4.9.1 (CVE-2022-0839)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.6.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -87,6 +87,7 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
+      <version>4.9.1</version>
     </dependency>
     <dependency>
       <groupId>io.github.openfeign</groupId>


### PR DESCRIPTION
Update Spring Boot from 2.6.6 to 2.6.7.

This indirectly updates spring-boot-starter-data-jpa from 2.6.6 to 2.6.7. This indirectly updates org.springframework:spring-context from 5.3.18 to 5.3.19 fixing Improper Handling of Case Sensitivity: https://nvd.nist.gov/vuln/detail/CVE-2022-22968

Update Liquibase from 4.5.0 to 4.9.1 fixing XML External Entity (XXE) Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-0839