### PR TITLE
FOLSPRINGB-52: Spring Boot 2.7.x for Morning Glory R2 2022

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.7</version>
+    <version>2.7.0-RC1</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -17,7 +17,7 @@
 
   <properties>
     <java.version>11</java.version>
-    <spring-cloud-starter-openfeign.version>3.1.0</spring-cloud-starter-openfeign.version>
+    <spring-cloud-starter-openfeign.version>3.1.2</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <cql2pgjson.version>33.2.4</cql2pgjson.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
@@ -26,7 +26,6 @@
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
     <lombok.version>1.18.16</lombok.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
-    <mockito.version>3.8.0</mockito.version>
     <easy-random.version>5.0.0</easy-random.version>
   </properties>
 
@@ -35,6 +34,11 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+    <repository>
+      <id>jfrog-nexus</id>
+      <name>Spring Milestone Maven Repository</name>
+      <url>https://repo.spring.io/milestone</url>
     </repository>
   </repositories>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0-RC1</version>
+    <version>2.7.0</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -34,11 +34,6 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
-    </repository>
-    <repository>
-      <id>jfrog-nexus</id>
-      <name>Spring Milestone Maven Repository</name>
-      <url>https://repo.spring.io/milestone</url>
     </repository>
   </repositories>
 


### PR DESCRIPTION
Migrate to Spring Boot 2.7.x.

https://spring.io/projects/spring-boot#support :

Open Source Support for Spring Boot 2.6.x ends 2022-11-24.

Open Source Support for Spring Boot 2.7.x ends 2023-05-18.

Morning Glory R2 2022 public release will be on 2022-08-08.

Nolana R3 2022 public release will be around 2022-12.

Orchid R1 2023 public release will be around 2023-04.

The support period for Morning Glory ends some time (to be determined) after Nolana public release date.

Therefore Spring Boot 2.6.x cannot be used for Morning Glory because Spring Boot support ends during the support period of Morning Glory.

For Morning Glory Spring Boot 2.7.x needs to be used so that we get security fixes during the complete support period.