### PR TITLE
Release 3.0.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 3.0.3 2022-05-04
+* [FOLSPRINGB-36](https://issues.folio.org/browse/FOLSPRINGB-36): Add postgres runtime dependency to pom.xml
+* [FOLSPRINGB-51](https://issues.folio.org/browse/FOLSPRINGB-51): Spring Boot 2.6.7 (CVE-2022-22968), Liquibase 4.9.1 (CVE-2022-0839)
+
 ## 3.0.2 2022-04-06
 * FOLSPRINGB-48 Upgrade to Spring Boot v2.6.6
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>folio-spring-base</artifactId>
-  <version>3.0.3-SNAPSHOT</version>
+  <version>3.0.3</version>
   <name>folio-spring-base</name>
   <description>This is a library (jar) that contains the basic functionality and main dependencies required for development FOLIO modules using
     Spring framework.
@@ -185,7 +185,7 @@
     <url>https://github.com/folio-org/folio-spring-base</url>
     <connection>scm:git:git@github.com:folio-org/folio-spring-base.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/folio-spring-base.git</developerConnection>
-    <tag>release/v3.0</tag>
+    <tag>v3.0.3</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,6 @@
     <java.version>11</java.version>
     <spring-cloud-starter-openfeign.version>3.1.0</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <postgresql.version>42.3.1</postgresql.version>
     <cql2pgjson.version>33.2.4</cql2pgjson.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
     <java.version>11</java.version>
     <spring-cloud-starter-openfeign.version>3.1.0</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
+    <postgresql.version>42.3.1</postgresql.version>
     <cql2pgjson.version>33.2.4</cql2pgjson.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>
@@ -83,6 +84,11 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <version>${postgresql.version}</version>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   </parent>
   <groupId>org.folio</groupId>
   <artifactId>folio-spring-base</artifactId>
-  <version>3.0.3</version>
+  <version>3.0.4-SNAPSHOT</version>
   <name>folio-spring-base</name>
   <description>This is a library (jar) that contains the basic functionality and main dependencies required for development FOLIO modules using
     Spring framework.
@@ -185,7 +185,7 @@
     <url>https://github.com/folio-org/folio-spring-base</url>
     <connection>scm:git:git@github.com:folio-org/folio-spring-base.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/folio-spring-base.git</developerConnection>
-    <tag>v3.0.3</tag>
+    <tag>release/v3.0</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.6</version>
+    <version>2.6.7</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -87,6 +87,7 @@
     <dependency>
       <groupId>org.liquibase</groupId>
       <artifactId>liquibase-core</artifactId>
+      <version>4.9.1</version>
     </dependency>
     <dependency>
       <groupId>io.github.openfeign</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${postgresql.version}</version>
+      <scope>runtime</scope>
     </dependency>
     <dependency>
       <groupId>org.liquibase</groupId>


### PR DESCRIPTION
* [FOLSPRINGB-36](https://issues.folio.org/browse/FOLSPRINGB-36): Add postgres runtime dependency to pom.xml
* [FOLSPRINGB-51](https://issues.folio.org/browse/FOLSPRINGB-51): Spring Boot 2.6.7 (CVE-2022-22968), Liquibase 4.9.1 (CVE-2022-0839)