### PR TITLE
FOLSPRINGB-53: Upgrade rhino and plexus-utils (CVE-2017-1000487)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,6 +145,25 @@
       <artifactId>mapstruct</artifactId>
       <version>${mapstruct.version}</version>
     </dependency>
+    <dependency>
+      <!-- Fix XML External Entity (XXE) Injection: https://security.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295
+           Remove this <dependecy> entry when org.openapitools:openapi-generator ships with a fixed version.
+      -->
+      <groupId>org.mozilla</groupId>
+      <artifactId>rhino</artifactId>
+      <version>1.7.14</version>
+    </dependency>
+    <dependency>
+      <!-- Fix plexus-utils issues:
+           Shell Command Injection https://nvd.nist.gov/vuln/detail/CVE-2017-1000487
+           XML External Entity (XXE) Injection: https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102
+           Directory Traversal https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521
+           Remove this <dependecy> entry after upgrading org.openapitools:openapi-generator to >= 6.0.0.
+      -->
+      <groupId>org.apache.maven</groupId>
+      <artifactId>maven-compat</artifactId>
+      <version>3.8.5</version>
+    </dependency>
 
     <!-- Test dependencies -->
     <dependency>


### PR DESCRIPTION
Upgrade dependencies that have vulnerabilities:

Upgrade org.mozilla:rhino from 1.7.7.2 to 1.7.14 fixing XML External Entity (XXE) Injection: https://app.snyk.io/vuln/SNYK-JAVA-ORGMOZILLA-1314295

Upgrade org.apache.maven:maven-compat from 3.5.0 to 3.8.5. This indirectly upgrades org.codehaus.plexus:plexus-utils from 1.5.8 to 3.3.0 fixing Shell Command Injection https://nvd.nist.gov/vuln/detail/CVE-2017-1000487 , XML External Entity (XXE) Injection https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-461102 , Directory Traversal https://app.snyk.io/vuln/SNYK-JAVA-ORGCODEHAUSPLEXUS-31521