### PR TITLE
FOLSPRINGB-68: Upgrade spring-security-rsa, bcprov-jdk15on, postgresql

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,18 @@
       <version>${spring-cloud-starter-openfeign.version}</version>
     </dependency>
     <dependency>
+      <!-- Remove this spring-security-rsa dependency as soon as spring-cloud-starter-openfeign
+           comes with spring-security-rsa >= 1.0.11.RELEASE
+           Fixing https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508
+           in org.bouncycastle:bcprov-jdk15on
+           No upstream release yet:
+           https://github.com/spring-cloud/spring-cloud-commons/commit/0525fb686b24d94c560f9f2cced9dc8a090ffa2a
+      -->
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-rsa</artifactId>
+      <version>1.0.11.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>${commons-lang3.version}</version>
@@ -86,6 +98,13 @@
     <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
+      <!-- spring-boot-starter-parent provides the org.postgresql:postgresql version, but it may be vulnerable:
+           postgresql doesn't back-port security fixes
+           https://github.com/pgjdbc/pgjdbc/issues/2599
+           and spring-boot-starter-parent doesn't bump the postgresql minor version
+           https://github.com/spring-projects/spring-boot/issues/32126
+      -->
+      <version>42.5.0</version>
       <scope>runtime</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade spring-security-rsa from 1.0.10.RELEASE to 1.0.11.RELEASE. This indirectly upgrades org.bouncycastle:bcprov-jdk15on from 1.68 to 1.69 fixing weak cryptography in HMAC: https://app.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508

Upgrade org.postgresql:postgresql from 42.3.5  to 42.5.0 fixing SQL Injection: https://nvd.nist.gov/vuln/detail/CVE-2022-31197

While it is more unlikely than likely that any folio-spring-base using module is affected by these issues it is more easy for each module to bump the folio-spring-base version than investigate whether it is affected by the issues.