### PR TITLE
FOLSPRINGB-70: snakeyaml security fix, Lombok, Spring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.0</version>
+    <version>2.7.3</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -17,14 +17,14 @@
 
   <properties>
     <java.version>11</java.version>
-    <spring-cloud-starter-openfeign.version>3.1.2</spring-cloud-starter-openfeign.version>
+    <spring-cloud-starter-openfeign.version>3.1.4</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <cql2pgjson.version>33.2.4</cql2pgjson.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>
     <feign-okhttp.version>11.7</feign-okhttp.version>
     <tenant.yaml.file>${project.basedir}/src/main/resources/swagger.api/tenant.yaml</tenant.yaml.file>
-    <lombok.version>1.18.16</lombok.version>
+    <lombok.version>1.18.24</lombok.version>
     <mapstruct.version>1.4.2.Final</mapstruct.version>
     <easy-random.version>5.0.0</easy-random.version>
   </properties>
@@ -72,18 +72,6 @@
       <groupId>org.springframework.cloud</groupId>
       <artifactId>spring-cloud-starter-openfeign</artifactId>
       <version>${spring-cloud-starter-openfeign.version}</version>
-    </dependency>
-    <dependency>
-      <!-- Remove this spring-security-rsa dependency as soon as spring-cloud-starter-openfeign
-           comes with spring-security-rsa >= 1.0.11.RELEASE
-           Fixing https://security.snyk.io/vuln/SNYK-JAVA-ORGBOUNCYCASTLE-2841508
-           in org.bouncycastle:bcprov-jdk15on
-           No upstream release yet:
-           https://github.com/spring-cloud/spring-cloud-commons/commit/0525fb686b24d94c560f9f2cced9dc8a090ffa2a
-      -->
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-rsa</artifactId>
-      <version>1.0.11.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -182,6 +170,18 @@
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-compat</artifactId>
       <version>3.8.5</version>
+    </dependency>
+    <dependency>
+      <!-- Fix Denial of Service (DoS) issue in snakeyaml:
+           https://nvd.nist.gov/vuln/detail/CVE-2022-25857
+           Spring Boot doesn't fix it before version 3.0.0:
+           https://github.com/spring-projects/spring-boot/issues/32221
+           openapi-generator doesn't have a release with fixed snakeyaml yet.
+           Remove this <dependency> entry when org.openapitools:openapi-generator ships with a fixed version.
+      -->
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.31</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Upgrade org.yaml:snakeyaml from 1.30 to 1.31 fixing these issues:

* Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-25857
* Stack-based Buffer Overflow https://nvd.nist.gov/vuln/detail/CVE-2022-38749
* Stack-based Buffer Overflow https://nvd.nist.gov/vuln/detail/CVE-2022-38750
* Stack-based Buffer Overflow https://nvd.nist.gov/vuln/detail/CVE-2022-38751
* Stack-based Buffer Overflow https://nvd.nist.gov/vuln/detail/CVE-2022-38752

Upgrade lombok from 1.18.16 to 1.18.24 allowing a build with JDK 17.

Upgrade spring-boot-starter-parent from 2.7.0 to 2.7.3.

Upgrade spring-cloud-starter-openfeign from 3.1.2 to 3.1.4. This indirectly upgrades spring-security-rsa to 1.0.11.RELEASE making an explicit dependency entry for spring-security-rsa obsolete.