### PR TITLE
FOLSPRINGB-75: snakeyaml 1.33 fixing Stack Overflow CVE-2022-38752

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -174,6 +174,8 @@
     <dependency>
       <!-- Fix Denial of Service (DoS) issue in snakeyaml:
            https://nvd.nist.gov/vuln/detail/CVE-2022-25857
+           Fix Stack-based Buffer Overflow issue in snakeyaml:
+           https://nvd.nist.gov/vuln/detail/CVE-2022-38752
            Spring Boot doesn't fix it before version 3.0.0:
            https://github.com/spring-projects/spring-boot/issues/32221
            openapi-generator doesn't have a release with fixed snakeyaml yet.
@@ -181,7 +183,7 @@
       -->
       <groupId>org.yaml</groupId>
       <artifactId>snakeyaml</artifactId>
-      <version>1.31</version>
+      <version>1.33</version>
     </dependency>
 
     <!-- Test dependencies -->


### PR DESCRIPTION
Upgrade snakeyaml from 1.31 to 1.33 fixing Denial of Service attacks (DoS) caused by Stack-based Buffer Overflow:
https://nvd.nist.gov/vuln/detail/CVE-2022-38752