### PR TITLE
FOLSPRINGB-73: Spring Cloud 4

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 buildMvn {
   publishModDescriptor = false
   mvnDeploy = true
-  buildNode = 'jenkins-agent-java11'
+  buildNode = 'jenkins-agent-java17'
 
   doApiLint = true
   doApiDoc = true

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.7.3</version>
+    <version>2.7.4</version>
     <relativePath /> <!-- lookup parent from repository -->
   </parent>
   <groupId>org.folio</groupId>
@@ -17,7 +17,7 @@
 
   <properties>
     <java.version>11</java.version>
-    <spring-cloud-starter-openfeign.version>3.1.4</spring-cloud-starter-openfeign.version>
+    <spring-cloud-starter-openfeign.version>4.0.0-M4</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
     <cql2pgjson.version>33.2.4</cql2pgjson.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
@@ -34,6 +34,14 @@
       <id>folio-nexus</id>
       <name>FOLIO Maven Repository</name>
       <url>https://repository.folio.org/repository/maven-folio</url>
+    </repository>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
     </repository>
   </repositories>
 

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -1,6 +1,7 @@
 spring:
   application:
     name: folio-spring-base
+  cloud.compatibility-verifier.enabled: false
   liquibase:
     enabled: true
     change-log: classpath:changelog-master.xml


### PR DESCRIPTION
Upgrading Spring Cloud from 3.1.4 to 4.0.0-M4.
Keeping Spring Boot at 2.7.*.

Note: This requires `spring.cloud.compatibility-verifier.enabled: false`, otherwise Spring Cloud 3 fails with error message that Spring Boot 2.7 is required.

Do we really want to combine these incompatible versions? We don't know whether these incompatibilities affect the areas that FOLIO uses.