### PR TITLE
Reverting changes to provide backward compatibility, to not force tea…

### DIFF
--- a/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
+++ b/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
@@ -4,7 +4,6 @@ import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.logging.FolioLoggingContextHolder;
-
 import org.springframework.core.NamedInheritableThreadLocal;
 
 import java.util.Map;
@@ -50,7 +49,7 @@ public class FolioExecutionScopeExecutionContextManager {
    *
    * <p>The visibility of this method is package-private to enforce using {@link FolioExecutionContextSetter}.
    */
-  static void beginFolioExecutionContext(FolioExecutionContext folioExecutionContext) {
+  public static void beginFolioExecutionContext(FolioExecutionContext folioExecutionContext) {
     var scopeMap = new ConcurrentHashMap<String, Object>();
     scopeMap.put(CONVERSATION_ID_KEY, UUID.randomUUID().toString());
     folioExecutionScopeHolder.set(scopeMap);
@@ -63,7 +62,7 @@ public class FolioExecutionScopeExecutionContextManager {
    *
    * <p>The visibility of this method is package-private to enforce using {@link FolioExecutionContextSetter}.
    */
-  static void endFolioExecutionContext() {
+  public static void endFolioExecutionContext() {
     folioExecutionContextHolder.remove();
     folioExecutionScopeHolder.remove();
     FolioLoggingContextHolder.removeFolioExecutionContext();


### PR DESCRIPTION
Reverting changes to provide backward compatibility, not to force teams to review all folio-spring-base based modules addressing this breaking change.

## Purpose
With the recent changes made with https://github.com/folio-org/folio-spring-base/pull/56, the breaking changes have been added. Because development teams do not have the extra capacity to address those changes in the scope of the Nolana release, it is necessary to provide backward compatibility to eliminate those breaking changes.

## Approach
Make two static methods within FolioExecutionScopeExecutionContextManager.java public again.

#### TODOS and Open Questions
N/A

## Learning
N/A
