### PR TITLE
FOLSPRINGB-78: RMB 35.0.1, commons-text 1.10.0 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <java.version>11</java.version>
     <spring-cloud-starter-openfeign.version>3.1.4</spring-cloud-starter-openfeign.version>
     <commons-lang3.version>3.12.0</commons-lang3.version>
-    <cql2pgjson.version>33.2.4</cql2pgjson.version>
+    <raml-module-builder.version>35.0.1</raml-module-builder.version>
     <openapi-generator.version>5.3.1</openapi-generator.version>
     <jackson-databind-nullable.version>0.2.2</jackson-databind-nullable.version>
     <feign-okhttp.version>11.7</feign-okhttp.version>
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>cql2pgjson</artifactId>
-      <version>${cql2pgjson.version}</version>
+      <version>${raml-module-builder.version}</version>
       <exclusions>
         <exclusion>
           <groupId>org.folio</groupId>
@@ -138,6 +138,18 @@
       </exclusions>
     </dependency>
     <dependency>
+      <!-- openapi-generator has commons-text 1.9 dependency,
+           commons-text 1.9 has Arbitrary Code Execution vulnerability:
+           https://nvd.nist.gov/vuln/detail/CVE-2022-42889
+           commons-text >= 1.10.0 has a fix.
+           Remove this commons-text dependency when openapi-generator comes
+           with a fixed commons-text dependency.
+      -->
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.10.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.openapitools</groupId>
       <artifactId>openapi-generator-maven-plugin</artifactId>
       <version>${openapi-generator.version}</version>
@@ -146,6 +158,11 @@
       <groupId>org.openapitools</groupId>
       <artifactId>jackson-databind-nullable</artifactId>
       <version>${jackson-databind-nullable.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
Upgrade jackson-databind from 2.13.3 to 2.13.4.2 fixing Denial of Service (DoS) vulnerabilities:
https://nvd.nist.gov/vuln/detail/CVE-2022-42003
https://nvd.nist.gov/vuln/detail/CVE-2022-42004

Upgrade commons-text from 1.9 to 1.10.0 fixing Arbitrary Code Execution
https://nvd.nist.gov/vuln/detail/CVE-2022-42889

Upgrade RMB from 33.2.4 to 35.0.1.
Note that org.folio:cql2pgjson is a component of RMB:
https://github.com/folio-org/raml-module-builder/tree/v35.0.1