### PR TITLE
Support for async execution with FolioExecutionContext

### DIFF
--- a/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
@@ -1,18 +1,18 @@
 package org.folio.spring;
 
-import static org.folio.spring.integration.XOkapiHeaders.OKAPI_HEADERS_PREFIX;
-import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
-import static org.folio.spring.integration.XOkapiHeaders.TENANT;
-import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
-import static org.folio.spring.integration.XOkapiHeaders.URL;
-import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
+import lombok.Getter;
 
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
-import lombok.Getter;
+import static org.folio.spring.integration.XOkapiHeaders.OKAPI_HEADERS_PREFIX;
+import static org.folio.spring.integration.XOkapiHeaders.REQUEST_ID;
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.folio.spring.integration.XOkapiHeaders.TOKEN;
+import static org.folio.spring.integration.XOkapiHeaders.URL;
+import static org.folio.spring.integration.XOkapiHeaders.USER_ID;
 
 @Getter
 public class DefaultFolioExecutionContext implements FolioExecutionContext {
@@ -44,6 +44,14 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
 
   private String retrieveFirstSafe(Collection<String> strings) {
     return strings != null && !strings.isEmpty() ? strings.iterator().next() : "";
+  }
+
+  /**
+   * A useful method to get an actual instance of the FolioExecutionContext when the one is injected through a wrapper
+   * @return
+   */
+  public FolioExecutionContext getInstance() {
+    return this;
   }
 
 }

--- a/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/DefaultFolioExecutionContext.java
@@ -46,12 +46,4 @@ public class DefaultFolioExecutionContext implements FolioExecutionContext {
     return strings != null && !strings.isEmpty() ? strings.iterator().next() : "";
   }
 
-  /**
-   * A useful method to get an actual instance of the FolioExecutionContext when the one is injected through a wrapper
-   * @return
-   */
-  public FolioExecutionContext getInstance() {
-    return this;
-  }
-
 }

--- a/src/main/java/org/folio/spring/FolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/FolioExecutionContext.java
@@ -57,4 +57,12 @@ public interface FolioExecutionContext {
   default FolioModuleMetadata getFolioModuleMetadata() {
     return null;
   }
+
+  /**
+   * A useful method to get an actual instance of the FolioExecutionContext when the one is injected through a wrapper
+   * Pay attention, that the result type must be Object, otherwise a proxy will return itselfb
+   */
+  default Object getInstance() {
+    return this;
+  }
 }

--- a/src/main/java/org/folio/spring/FolioExecutionContext.java
+++ b/src/main/java/org/folio/spring/FolioExecutionContext.java
@@ -59,8 +59,8 @@ public interface FolioExecutionContext {
   }
 
   /**
-   * A useful method to get an actual instance of the FolioExecutionContext when the one is injected through a wrapper
-   * Pay attention, that the result type must be Object, otherwise a proxy will return itselfb
+   * A useful method to get an actual instance of the FolioExecutionContext when the one is injected through a wrapper/proxy
+   * Pay attention, that the result type must be Object, otherwise a proxy will return itself
    */
   default Object getInstance() {
     return this;

--- a/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
+++ b/src/main/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManager.java
@@ -2,7 +2,6 @@ package org.folio.spring.scope;
 
 import lombok.experimental.UtilityClass;
 import lombok.extern.log4j.Log4j2;
-import org.folio.spring.DefaultFolioExecutionContext;
 import org.folio.spring.FolioExecutionContext;
 import org.folio.spring.logging.FolioLoggingContextHolder;
 import org.springframework.core.NamedInheritableThreadLocal;
@@ -74,8 +73,7 @@ public class FolioExecutionScopeExecutionContextManager {
    * and reset it once the task is completed.
    */
   public static Runnable getRunnableWithFolioContext(FolioExecutionContext executionContext, Runnable task) {
-    final FolioExecutionContext localInstance =
-      (executionContext instanceof DefaultFolioExecutionContext) ? ((DefaultFolioExecutionContext) executionContext).getInstance() : executionContext;
+    final FolioExecutionContext localInstance = (FolioExecutionContext) executionContext.getInstance();
     return () -> {
       beginFolioExecutionContext(localInstance);
       try {

--- a/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
+++ b/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
@@ -1,0 +1,87 @@
+package org.folio.spring.scope;
+
+import org.apache.commons.lang3.StringUtils;
+import org.folio.spring.DefaultFolioExecutionContext;
+import org.folio.spring.FolioExecutionContext;
+import org.folio.spring.FolioModuleMetadata;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.folio.spring.integration.XOkapiHeaders.TENANT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest(classes = {FolioExecutionScopeExecutionContextManagerTest.TestConfiguration.class, FolioExecutionScopeConfig.class},
+  properties = {
+    "spring.application.name=TestFolioSpringBaseApplication"
+  })
+class FolioExecutionScopeExecutionContextManagerTest {
+  @Autowired
+  private FolioExecutionContext folioExecutionContext;
+
+  @Autowired
+  private FolioModuleMetadata folioModuleMetadata;
+
+  @Test
+  void getRunnableWithFolioContext() {
+    Collection<String> headerValueCollection = List.of("dummy-tenanant-1");
+    var allHeaders = Map.of(TENANT, headerValueCollection);
+    var localFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, allHeaders);
+    var task = FolioExecutionScopeExecutionContextManager.getRunnableWithFolioContext(localFolioExecutionContext, () -> {
+      var tenantId = folioExecutionContext.getTenantId();
+      var localTenantId = localFolioExecutionContext.getTenantId();
+      assertEquals(tenantId, localTenantId);
+    });
+
+    task.run();
+  }
+
+  @Test
+  void getRunnableWithCurrentFolioContext() {
+    Collection<String> headerValueCollection = List.of("dummy-tenanant-1");
+    var allHeaders = Map.of(TENANT, headerValueCollection);
+    var localFolioExecutionContext = new DefaultFolioExecutionContext(folioModuleMetadata, allHeaders);
+    Runnable task;
+    FolioExecutionScopeExecutionContextManager.beginFolioExecutionContext(localFolioExecutionContext);
+    try {
+      task = FolioExecutionScopeExecutionContextManager.getRunnableWithCurrentFolioContext(() -> {
+        var tenantId = folioExecutionContext.getTenantId();
+        var localTenantId = localFolioExecutionContext.getTenantId();
+        assertEquals(tenantId, localTenantId);
+      });
+    } finally {
+      FolioExecutionScopeExecutionContextManager.endFolioExecutionContext();
+    }
+    task.run();
+  }
+
+  @Configuration
+  static class TestConfiguration {
+    @Bean
+    public FolioModuleMetadata folioModuleMetadata(@Value("${spring.application.name}") String applicationName) {
+      var schemaSuffix = StringUtils.isNotBlank(applicationName) ? "_" + applicationName.toLowerCase().replace('-', '_') : "";
+      return new FolioModuleMetadata() {
+        @Override
+        public String getModuleName() {
+          return applicationName;
+        }
+
+        @Override
+        public String getDBSchemaName(String tenantId) {
+          if (StringUtils.isBlank(tenantId)) {
+            throw new IllegalArgumentException("tenantId can't be null or empty");
+          }
+          return tenantId.toLowerCase() + schemaSuffix;
+        }
+      };
+    }
+  }
+
+}

--- a/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
+++ b/src/test/java/org/folio/spring/scope/FolioExecutionScopeExecutionContextManagerTest.java
@@ -55,6 +55,8 @@ class FolioExecutionScopeExecutionContextManagerTest {
         var tenantId = folioExecutionContext.getTenantId();
         var localTenantId = localFolioExecutionContext.getTenantId();
         assertEquals(tenantId, localTenantId);
+        var instance = folioExecutionContext.getInstance();
+        assertEquals(localFolioExecutionContext, instance);
       });
     } finally {
       FolioExecutionScopeExecutionContextManager.endFolioExecutionContext();


### PR DESCRIPTION
## Purpose
There is no common solution for cases when an asynchronous task should be executed using a particular FolioExecutionContext instance. This PR provides the implementation for such cases.

## Approach
The approach is to wrap a runnable instance and set up the context right before executing Runnable.run(); and clear the context right after the execution.

#### TODOS and Open Questions
N/A

## Learning
N/A
