### PR TITLE
Fix issue with the race condition with CqlParser shared object

### DIFF
--- a/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
+++ b/src/main/java/org/folio/spring/cql/Cql2JpaCriteria.java
@@ -45,12 +45,10 @@ public class Cql2JpaCriteria<E> {
 
   private final Class<E> domainClass;
   private final EntityManager em;
-  private final CQLParser cqlParser;
 
   public Cql2JpaCriteria(Class<E> domainClass, EntityManager entityManager) {
     this.domainClass = domainClass;
     this.em = entityManager;
-    this.cqlParser = new CQLParser();
   }
 
   /**
@@ -61,7 +59,7 @@ public class Cql2JpaCriteria<E> {
    */
   public CriteriaQuery<E> toCollectCriteria(String cql) {
     try {
-      var node = cqlParser.parse(cql);
+      var node = new CQLParser().parse(cql);
 
       var cb = em.getCriteriaBuilder();
       var query = cb.createQuery(domainClass);
@@ -83,7 +81,7 @@ public class Cql2JpaCriteria<E> {
    */
   public CriteriaQuery<Long> toCountCriteria(String cql) {
     try {
-      var node = cqlParser.parse(cql);
+      var node = new CQLParser().parse(cql);
 
       var cb = em.getCriteriaBuilder();
       var query = cb.createQuery(Long.class);


### PR DESCRIPTION
## Purpose
Because of the shared CqlParser instance, a race condition can occur when processing CQL statements by the JpaCqlRepositoryImpl.

## Approach
Instantiate a new instance for every CQL parsing operation

