### PR TITLE
FOLSPRINGB-99 - Add support for filtering by date range in JpaCqlRepository

### DIFF
--- a/src/test/java/org/folio/spring/cql/JpaCqlRepositoryTest.java
+++ b/src/test/java/org/folio/spring/cql/JpaCqlRepositoryTest.java
@@ -8,6 +8,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.zonky.test.db.AutoConfigureEmbeddedDatabase;
+
+import java.sql.Timestamp;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.List;
 import java.util.stream.Stream;
 import org.folio.spring.cql.domain.City;
@@ -206,6 +210,17 @@ class JpaCqlRepositoryTest {
 
     assertTrue(thrown.getMessage().contains("Not implemented yet"));
   }
+
+  @Test
+  void testFilterByDates() {
+    var page = personRepository.findByCQL("dateBorn=2001-01-01:2001-01-02", OffsetRequest.of(0, 10));
+    assertThat(page)
+      .hasSize(2)
+      .extracting(Person::getDateBorn)
+      .contains(Timestamp.from(LocalDate.parse("2001-01-01").atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()),
+        Timestamp.from(LocalDate.parse("2001-01-02").atStartOfDay().atZone(ZoneId.systemDefault()).toInstant()));
+  }
+
 
   static Stream<Arguments> testLikeMasking() {
     return Stream.of(

--- a/src/test/resources/insert-data.sql
+++ b/src/test/resources/insert-data.sql
@@ -1,9 +1,9 @@
 insert into city(id, name) values (1, 'Kharkiv');
 insert into city(id, name) values (2, 'Kyiv');
 
-insert into person(id, name, age, city_id) values (101, 'Jane', 20, 1);
-insert into person(id, name, age, city_id) values (102, 'John', 22, 2);
-insert into person(id, name, age, city_id) values (103, 'John', 40, 1);
+insert into person(id, name, age, city_id, date_born) values (101, 'Jane', 20, 1, '2001-01-03');
+insert into person(id, name, age, city_id, date_born) values (102, 'John', 22, 2, '2001-01-01');
+insert into person(id, name, age, city_id, date_born) values (103, 'John', 40, 1, '2001-01-02');
 
 insert into str(id, str) values
   (1, 'a'),


### PR DESCRIPTION
[FOLSPRINGB-99](https://issues.folio.org/browse/FOLSPRINGB-99) - Add support for filtering by date range in JpaCqlRepository

## Purpose
UI uses CQL queries like "yyyy-MM-dd:yyyy-MM-dd" to filter data by dates range. Those queries should be supported by folio-spring-base.

## Approach
* Added required logic
* Updated unit tests